### PR TITLE
fix(blog): break 308 redirect loop on normalized blog slug

### DIFF
--- a/frontend/apps/web/next.config.mjs
+++ b/frontend/apps/web/next.config.mjs
@@ -27,14 +27,12 @@ const nextConfig = {
   },
 
   async redirects() {
-    return [
-      // Slug normalized to lowercase kebab-case (2026-06-09); old URL may be indexed
-      {
-        source: '/blog/What-is-competitive-intelligence',
-        destination: '/blog/what-is-competitive-intelligence',
-        permanent: true,
-      },
-    ]
+    // NOTE: redirect `source` matching is case-INSENSITIVE (path-to-regexp
+    // sensitive:false), so a source that only differs from its destination by
+    // case matches the destination too and loops forever. The old indexed
+    // `/blog/What-is-competitive-intelligence` URL is handled in proxy.ts with
+    // a case-SENSITIVE check instead.
+    return []
   },
 
   async headers() {

--- a/frontend/apps/web/proxy.ts
+++ b/frontend/apps/web/proxy.ts
@@ -31,6 +31,15 @@ export function proxy(req: NextRequest): NextResponse {
     return NextResponse.redirect(buildApexUrl(host, req.nextUrl.protocol, `${pathname}${search}`))
   }
 
+  // Legacy blog slug (pre 2026-06-09 normalization) may still be indexed.
+  // Lives here instead of next.config redirects(): those match the source
+  // case-INSENSITIVELY, so a case-only redirect loops on its own destination.
+  if (pathname === '/blog/What-is-competitive-intelligence') {
+    const url = req.nextUrl.clone()
+    url.pathname = '/blog/what-is-competitive-intelligence'
+    return NextResponse.redirect(url, 308)
+  }
+
   // Apex (no tenant) — public site renders normally.
   if (!tenant) {
     return NextResponse.next()


### PR DESCRIPTION
next.config redirects() match the source case-insensitively (path-to-regexp sensitive:false), so the case-only redirect for /blog/What-is-competitive-intelligence also matched its own lowercase destination and redirected to itself forever. Moved the legacy-slug redirect into proxy.ts where the comparison is case-sensitive.