### PR TITLE
fix(blog): stop 500s on ISR pages caused by headers() in root layout

### DIFF
--- a/frontend/apps/web/app/(app)/layout.tsx
+++ b/frontend/apps/web/app/(app)/layout.tsx
@@ -1,13 +1,10 @@
-import { extractTenantFromHostname } from '@workspace/shared-http'
 import type { Metadata } from 'next'
 import { DM_Sans, DM_Serif_Display, Geist, Geist_Mono, Outfit, Syne } from 'next/font/google'
-import { headers } from 'next/headers'
-import Script from 'next/script'
 
 import '@workspace/ui/globals.css'
+import { AnalyticsScripts } from '@/components/analytics-scripts'
 import { JsonLd } from '@/components/json-ld'
 import { Providers } from '@/components/providers'
-import { env } from '@/lib/env'
 import { NotificationProvider } from '@/lib/notification'
 
 const metadataBase = process.env.NEXT_PUBLIC_APP_BASE_URL
@@ -138,21 +135,11 @@ const websiteJsonLd = {
   },
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  // GA only on the apex (public marketing site, e.g. pulzifi.com), never on
-  // tenant subdomains (the authenticated app surface).
-  const headersList = await headers()
-  const hostname = headersList.get('x-forwarded-host') || headersList.get('host') || ''
-  const isApex = extractTenantFromHostname(hostname) === null
-  const gaId = env.NEXT_PUBLIC_GA_ID
-  const enableGa = isApex && Boolean(gaId)
-  const metaPixelId = env.NEXT_PUBLIC_META_PIXEL_ID
-  const enableMetaPixel = isApex && Boolean(metaPixelId)
-
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -163,48 +150,7 @@ export default async function RootLayout({
         <JsonLd data={websiteJsonLd} />
         <Providers>{children}</Providers>
         <NotificationProvider />
-        {enableGa && (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-              strategy="afterInteractive"
-            />
-            {/* biome-ignore lint/correctness/useUniqueElementIds: next/script inline tag needs a stable, single-use id for GA */}
-            <Script id="ga-gtag" strategy="afterInteractive">
-              {`window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '${gaId}');`}
-            </Script>
-          </>
-        )}
-        {enableMetaPixel && (
-          <>
-            {/* biome-ignore lint/correctness/useUniqueElementIds: next/script inline tag needs a stable, single-use id for the Meta Pixel */}
-            <Script id="meta-pixel" strategy="afterInteractive">
-              {`!function(f,b,e,v,n,t,s)
-{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-n.queue=[];t=b.createElement(e);t.async=!0;
-t.src=v;s=b.getElementsByTagName(e)[0];
-s.parentNode.insertBefore(t,s)}(window, document,'script',
-'https://connect.facebook.net/en_US/fbevents.js');
-fbq('init', '${metaPixelId}');
-fbq('track', 'PageView');`}
-            </Script>
-            <noscript>
-              {/* biome-ignore lint/performance/noImgElement: Meta Pixel fallback must be a plain <img> inside <noscript> — next/image requires JS and cannot render here */}
-              <img
-                height="1"
-                width="1"
-                style={{ display: 'none' }}
-                alt=""
-                src={`https://www.facebook.com/tr?id=${metaPixelId}&ev=PageView&noscript=1`}
-              />
-            </noscript>
-          </>
-        )}
+        <AnalyticsScripts />
       </body>
     </html>
   )

--- a/frontend/apps/web/components/analytics-scripts.tsx
+++ b/frontend/apps/web/components/analytics-scripts.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+// Deep import (not the package barrel) to keep axios out of this client chunk.
+import { extractTenantFromHostname } from '@workspace/shared-http/tenant-utils'
+import Script from 'next/script'
+import { useEffect, useState } from 'react'
+
+import { env } from '@/lib/env'
+
+/**
+ * GA + Meta Pixel, only on the apex (public marketing site) — never on tenant
+ * subdomains (the authenticated app surface).
+ *
+ * Client component on purpose: the apex check needs the request hostname, and
+ * reading it server-side (next/headers) is a dynamic API that breaks static/ISR
+ * rendering of every page under the root layout (digest DYNAMIC_SERVER_USAGE).
+ * In the browser the hostname is free, and the scripts are afterInteractive
+ * anyway, so nothing is lost by deciding after mount.
+ */
+export function AnalyticsScripts() {
+  const [isApex, setIsApex] = useState(false)
+
+  useEffect(() => {
+    setIsApex(extractTenantFromHostname(window.location.hostname) === null)
+  }, [])
+
+  const gaId = env.NEXT_PUBLIC_GA_ID
+  const metaPixelId = env.NEXT_PUBLIC_META_PIXEL_ID
+
+  if (!isApex) return null
+
+  return (
+    <>
+      {gaId && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+            strategy="afterInteractive"
+          />
+          {/* biome-ignore lint/correctness/useUniqueElementIds: next/script inline tag needs a stable, single-use id for GA */}
+          <Script id="ga-gtag" strategy="afterInteractive">
+            {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${gaId}');`}
+          </Script>
+        </>
+      )}
+      {metaPixelId && (
+        <>
+          {/* biome-ignore lint/correctness/useUniqueElementIds: next/script inline tag needs a stable, single-use id for the Meta Pixel */}
+          <Script id="meta-pixel" strategy="afterInteractive">
+            {`!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '${metaPixelId}');
+fbq('track', 'PageView');`}
+          </Script>
+        </>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
The apex-only GA/Meta Pixel gate read the hostname via next/headers in the root layout, which is a dynamic API. Every page under the layout that opts into static/ISR rendering (blog detail, revalidate=3600) threw DynamicServerError (digest DYNAMIC_SERVER_USAGE) and returned a plain 500 in production. The gate now lives in a client component that reads window.location.hostname after mount — the scripts were afterInteractive anyway, so behavior is unchanged and the layout is static-safe again.