### PR TITLE
fix(blog): render blog index dynamically to avoid empty build-time shell

### DIFF
--- a/frontend/apps/web/app/(app)/(cms)/blog/page.tsx
+++ b/frontend/apps/web/app/(app)/(cms)/blog/page.tsx
@@ -26,7 +26,12 @@ function toBlogPostItem(post: PostDoc): BlogPostItem {
   }
 }
 
-export const revalidate = 3600
+// Dynamic on purpose: this route has no params, so ISR would prerender it AT
+// BUILD TIME, where Payload/Postgres is unreachable — the empty "No posts yet"
+// shell would then be cached for the whole revalidate window after every
+// deploy. Detail pages keep ISR because they generate on demand (at runtime,
+// with the DB available). The Payload local query here is a few ms.
+export const dynamic = 'force-dynamic'
 
 const BLOG_TITLE = 'Website Monitoring Blog — Insights & Guides | Pulzifi'
 const BLOG_DESCRIPTION =


### PR DESCRIPTION
With the layout now static-safe, the index (a no-param route) was prerendered at build where Payload/Postgres is unreachable, caching the "No posts published yet" shell for the full revalidate hour after every deploy. force-dynamic restores the per-request fetch the page effectively had before; detail pages keep ISR since they generate on demand at runtime.