### PR TITLE
feat(seo): guarantee share preview image on every public page

### DIFF
--- a/frontend/apps/web/app/(app)/(cms)/blog/[slug]/page.tsx
+++ b/frontend/apps/web/app/(app)/(cms)/blog/[slug]/page.tsx
@@ -80,9 +80,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         ? (meta.image as Record<string, unknown>)
         : null
     // Share image prefers the dedicated SEO/OG image (meta.image), falling back
-    // to the article hero so posts without a custom OG image still get one.
+    // to the article hero, then the site-wide OG image. The last fallback must
+    // be explicit: a page-level openGraph object REPLACES the layout's wholesale
+    // (shallow merge per top-level key), so omitting images would share without one.
     const heroImageUrl =
-      ((metaImageObj?.url ?? heroImageObj?.url) as string | undefined)?.trim() || undefined
+      ((metaImageObj?.url ?? heroImageObj?.url) as string | undefined)?.trim() ||
+      `${siteUrl}/opengraph-image`
     const publishedAt = post.publishedAt as string | undefined
     const author = post.author as string | undefined
 

--- a/frontend/apps/web/app/(app)/(cms)/blog/page.tsx
+++ b/frontend/apps/web/app/(app)/(cms)/blog/page.tsx
@@ -48,11 +48,24 @@ export const metadata: Metadata = {
     title: BLOG_TITLE,
     description: BLOG_DESCRIPTION,
     url: '/blog',
+    // Explicit: page-level openGraph REPLACES the layout's wholesale (shallow
+    // merge per top-level key), so omitting images here would share without one.
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: BLOG_TITLE,
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: BLOG_TITLE,
     description: BLOG_DESCRIPTION,
+    images: [
+      '/opengraph-image',
+    ],
   },
   robots: {
     index: true,
@@ -66,7 +79,9 @@ export default async function BlogIndexPage() {
   // Payload is unavailable at build time (getPayloadClient throws). Fall back to
   // an empty list so the static shell prerenders; ISR (revalidate) then fills in
   // real posts on the first runtime revalidation.
-  let posts = { docs: [] as PostDoc[] }
+  let posts = {
+    docs: [] as PostDoc[],
+  }
   let chrome = {
     themeStyle: '',
     navbar: {},
@@ -88,7 +103,9 @@ export default async function BlogIndexPage() {
       }),
       fetchCmsChrome(),
     ])
-    posts = postsResult as unknown as { docs: PostDoc[] }
+    posts = postsResult as unknown as {
+      docs: PostDoc[]
+    }
     chrome = cmsChrome
   } catch {
     // build-time fallback — keep defaults

--- a/frontend/apps/web/app/(app)/(public)/contact/layout.tsx
+++ b/frontend/apps/web/app/(app)/(public)/contact/layout.tsx
@@ -10,11 +10,25 @@ export const metadata: Metadata = {
     description:
       'Reach out for enterprise inquiries, support, or partnerships. Our team responds within one business day.',
     type: 'website',
+    url: '/contact',
+    // Explicit: page-level openGraph REPLACES the layout's wholesale (shallow
+    // merge per top-level key), so omitting images here would share without one.
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: 'Contact Pulzifi',
+      },
+    ],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Contact Pulzifi',
     description: 'Reach out for enterprise inquiries, support, or partnerships.',
+    images: [
+      '/opengraph-image',
+    ],
   },
   alternates: {
     canonical: '/contact',


### PR DESCRIPTION
Next.js merges metadata shallowly per top-level key: a page-level openGraph object without images replaces the layout's wholesale, so blog index, heroless blog posts, and contact shared with no card image. All three now set /opengraph-image explicitly as the fallback, and contact upgrades its twitter card from summary to summary_large_image.