### PR TITLE
feat(demo): toggle lecture-ai page version via file-backed demo state

### DIFF
--- a/frontend/apps/web/app/(app)/(demo)/lecture-ai/page.tsx
+++ b/frontend/apps/web/app/(app)/(demo)/lecture-ai/page.tsx
@@ -1,3 +1,4 @@
+import { getDemoState } from '@/lib/demo-store'
 import { Badge } from '@workspace/ui/components/atoms/badge'
 import { Button } from '@workspace/ui/components/atoms/button'
 import {
@@ -17,8 +18,10 @@ import type { ReactNode } from 'react'
 import { CompareBars } from './compare-bars'
 import { WaveBars } from './wave-bars'
 
+export const dynamic = 'force-dynamic'
+
 export default function LectureAiLandingPage() {
-  const v = '2'
+  const { lectureAiVersion: v } = getDemoState()
 
   const isV2 = v === '2'
 

--- a/frontend/apps/web/app/(app)/api/demo/lecture-ai/route.ts
+++ b/frontend/apps/web/app/(app)/api/demo/lecture-ai/route.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getDemoState, setDemoState } from '@/lib/demo-store'
+
+export function GET() {
+  return NextResponse.json(getDemoState())
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const version = body?.version
+  if (version !== '1' && version !== '2') {
+    return NextResponse.json({ error: 'version must be "1" or "2"' }, { status: 400 })
+  }
+  const state = setDemoState({ lectureAiVersion: version })
+  return NextResponse.json(state)
+}

--- a/frontend/apps/web/lib/demo-store.ts
+++ b/frontend/apps/web/lib/demo-store.ts
@@ -1,0 +1,25 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const FILE = join(process.cwd(), '.demo-state.json')
+
+type DemoState = {
+  lectureAiVersion: '1' | '2'
+}
+
+const DEFAULT: DemoState = { lectureAiVersion: '2' }
+
+export function getDemoState(): DemoState {
+  try {
+    if (!existsSync(FILE)) return DEFAULT
+    return JSON.parse(readFileSync(FILE, 'utf-8'))
+  } catch {
+    return DEFAULT
+  }
+}
+
+export function setDemoState(patch: Partial<DemoState>): DemoState {
+  const next = { ...getDemoState(), ...patch }
+  writeFileSync(FILE, JSON.stringify(next))
+  return next
+}


### PR DESCRIPTION
The demo page version was hardcoded; it now reads from a .demo-state.json store switchable at runtime through GET/POST /api/demo/lecture-ai, with force-dynamic so the page reflects the toggle without a rebuild.