### PR TITLE
fix(monitoring): include section_id in SSE check events

### DIFF
--- a/modules/monitoring/application/orchestrator/orchestrator.go
+++ b/modules/monitoring/application/orchestrator/orchestrator.go
@@ -41,15 +41,16 @@ type RepositoryFactory interface {
 // checkEvent is the DTO published via SSE when a check is created or fails at dispatch.
 // It mirrors listchecks.CheckResponse to keep the SSE payload consistent.
 type checkEvent struct {
-	ID              uuid.UUID `json:"id"`
-	PageID          uuid.UUID `json:"page_id"`
-	Status          string    `json:"status"`
-	ScreenshotURL   string    `json:"screenshot_url"`
-	HTMLSnapshotURL string    `json:"html_snapshot_url"`
-	ChangeDetected  bool      `json:"change_detected"`
-	ChangeType      string    `json:"change_type"`
-	ErrorMessage    string    `json:"error_message,omitempty"`
-	CheckedAt       time.Time `json:"checked_at"`
+	ID              uuid.UUID  `json:"id"`
+	PageID          uuid.UUID  `json:"page_id"`
+	SectionID       *uuid.UUID `json:"section_id,omitempty"`
+	Status          string     `json:"status"`
+	ScreenshotURL   string     `json:"screenshot_url"`
+	HTMLSnapshotURL string     `json:"html_snapshot_url"`
+	ChangeDetected  bool       `json:"change_detected"`
+	ChangeType      string     `json:"change_type"`
+	ErrorMessage    string     `json:"error_message,omitempty"`
+	CheckedAt       time.Time  `json:"checked_at"`
 }
 
 type Orchestrator struct {
@@ -150,9 +151,12 @@ func (o *Orchestrator) publishCheckEvent(check *entities.Check) {
 	if o.onCheckCreated == nil {
 		return
 	}
+	// SectionID must travel with the event: the checks-history UI filters
+	// section checks by this field (see notifyCheckDone in the snapshot worker).
 	payload, err := json.Marshal(checkEvent{
 		ID:              check.ID,
 		PageID:          check.PageID,
+		SectionID:       check.SectionID,
 		Status:          check.Status,
 		ScreenshotURL:   check.ScreenshotURL,
 		HTMLSnapshotURL: check.HTMLSnapshotURL,

--- a/modules/monitoring/infrastructure/http/module.go
+++ b/modules/monitoring/infrastructure/http/module.go
@@ -120,10 +120,12 @@ func NewModuleWithDeps(deps Deps) *Module {
 			logger.Error("failCheck: failed to update check status", zap.Error(updateErr), zap.String("check_id", checkID.String()))
 			return
 		}
-		// Publish the failed check to SSE subscribers.
+		// Publish the failed check to SSE subscribers. SectionID included so the
+		// checks-history UI can filter section checks out of the history list.
 		payload, _ := json.Marshal(listchecks.CheckResponse{
 			ID:              check.ID,
 			PageID:          check.PageID,
+			SectionID:       check.SectionID,
 			Status:          check.Status,
 			ScreenshotURL:   check.ScreenshotURL,
 			HTMLSnapshotURL: check.HTMLSnapshotURL,

--- a/modules/snapshot/application/worker.go
+++ b/modules/snapshot/application/worker.go
@@ -68,19 +68,24 @@ func (s *SnapshotWorker) notifyCheckDone(check *snapEntities.Check) {
 		return
 	}
 	type checkResponse struct {
-		ID              uuid.UUID `json:"id"`
-		PageID          uuid.UUID `json:"page_id"`
-		Status          string    `json:"status"`
-		ScreenshotURL   string    `json:"screenshot_url"`
-		HTMLSnapshotURL string    `json:"html_snapshot_url"`
-		ChangeDetected  bool      `json:"change_detected"`
-		ChangeType      string    `json:"change_type"`
-		ErrorMessage    string    `json:"error_message,omitempty"`
-		CheckedAt       string    `json:"checked_at"`
+		ID              uuid.UUID  `json:"id"`
+		PageID          uuid.UUID  `json:"page_id"`
+		SectionID       *uuid.UUID `json:"section_id,omitempty"`
+		Status          string     `json:"status"`
+		ScreenshotURL   string     `json:"screenshot_url"`
+		HTMLSnapshotURL string     `json:"html_snapshot_url"`
+		ChangeDetected  bool       `json:"change_detected"`
+		ChangeType      string     `json:"change_type"`
+		ErrorMessage    string     `json:"error_message,omitempty"`
+		CheckedAt       string     `json:"checked_at"`
 	}
+	// SectionID must travel with the event: the checks-history UI keeps only
+	// full-page checks and filters section checks by this field — without it a
+	// section completion renders as a duplicate history entry.
 	payload, err := json.Marshal(checkResponse{
 		ID:              check.ID,
 		PageID:          check.PageID,
+		SectionID:       check.SectionID,
 		Status:          check.Status,
 		ScreenshotURL:   check.ScreenshotURL,
 		HTMLSnapshotURL: check.HTMLSnapshotURL,


### PR DESCRIPTION
The checks-history UI filters section checks out of the history list by the event's section_id, but none of the three SSE publishers (snapshot worker completion, orchestrator pending/dispatch-failure, worker-pool failCheck) serialized the field. A section check completion therefore passed the filter and rendered as a duplicate history entry until reload, where the list endpoint filters correctly.