### PR TITLE
fix(integration): deliver change alerts via worker dispatch

### DIFF
--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -381,6 +381,7 @@ func buildIntegrationModule(
 	intOrgGuard := intwiring.NewOrgGuard(orgRepo)
 	intChannelEntitlement := intwiring.NewChannelEntitlementAdapter(twilioPlanLookup, cfg.IntegrationPaidPlans)
 	intDispatcher := dispatchevent.NewHandlerWithEntitlement(intRepoFactory, intOrgGuard, intChannelEntitlement)
+	intDispatcher.SetFallbackResolver(intwiring.NewMemberEmailResolver(db))
 
 	subscribeIntegrationEvents(eventBus, intDispatcher)
 

--- a/cmd/wiring/integration/member_email_resolver.go
+++ b/cmd/wiring/integration/member_email_resolver.go
@@ -1,0 +1,58 @@
+package intwiring
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jcsoftdev/pulzifi-back/shared/database"
+)
+
+// MemberEmailResolver resolves a workspace's active member emails for the
+// integration dispatcher's default-email fallback (seed a workspace email
+// destination when none is configured). It excludes removed members, soft-deleted
+// users, and users who turned off email notifications — mirroring the social
+// emailer's recipient query.
+type MemberEmailResolver struct {
+	db *sql.DB
+}
+
+// NewMemberEmailResolver builds a MemberEmailResolver backed by the shared DB pool.
+func NewMemberEmailResolver(db *sql.DB) *MemberEmailResolver {
+	return &MemberEmailResolver{db: db}
+}
+
+// WorkspaceMemberEmails returns the email addresses of all active members of the
+// given workspace within the tenant schema.
+func (r *MemberEmailResolver) WorkspaceMemberEmails(ctx context.Context, tenant string, workspaceID uuid.UUID) ([]string, error) {
+	var emails []string
+	err := database.WithTenant(ctx, r.db, tenant, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx,
+			`SELECT u.email
+			   FROM workspace_members wm
+			   JOIN public.users u ON u.id = wm.user_id
+			  WHERE wm.workspace_id = $1
+			    AND wm.removed_at IS NULL
+			    AND u.deleted_at IS NULL
+			    AND COALESCE(u.email_notifications_enabled, TRUE) = TRUE`, workspaceID)
+		if err != nil {
+			return fmt.Errorf("resolve workspace member emails for %s: %w", workspaceID, err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var email string
+			if err := rows.Scan(&email); err != nil {
+				return err
+			}
+			if email != "" {
+				emails = append(emails, email)
+			}
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return emails, nil
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -15,6 +15,7 @@ import (
 	workerjobs "github.com/jcsoftdev/pulzifi-back/cmd/worker/jobs"
 	emailservices "github.com/jcsoftdev/pulzifi-back/modules/email/domain/services"
 	emailproviders "github.com/jcsoftdev/pulzifi-back/modules/email/infrastructure/providers"
+	dispatchevent "github.com/jcsoftdev/pulzifi-back/modules/integration/application/dispatch_event"
 	"github.com/jcsoftdev/pulzifi-back/modules/integration/domain/services"
 	intpersistence "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/persistence"
 	intproviders "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/providers"
@@ -28,6 +29,7 @@ import (
 	twilioprovider "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/providers/twilio"
 	deliveryworker "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/worker"
 	monitoring "github.com/jcsoftdev/pulzifi-back/modules/monitoring/infrastructure/http"
+	orgpersistence "github.com/jcsoftdev/pulzifi-back/modules/organization/infrastructure/persistence"
 	socialscheduler "github.com/jcsoftdev/pulzifi-back/modules/social/infrastructure/scheduler"
 	"github.com/jcsoftdev/pulzifi-back/shared/cache"
 	"github.com/jcsoftdev/pulzifi-back/shared/config"
@@ -76,6 +78,12 @@ func main() {
 	defer bus.Close()
 
 	emailProvider := emailproviders.NewResendProvider(cfg.ResendAPIKey, cfg.EmailFromAddress, cfg.EmailFromName)
+
+	// Wire the integration dispatcher onto the worker's bus BEFORE detection starts.
+	// Change detection runs in THIS process and publishes change.detected / alert.created
+	// events; without a subscriber here, the in-memory bus drops them and no integration
+	// delivery (email destinations, Slack, etc.) is ever created. Mirrors cmd/server.
+	subscribeIntegrationEvents(db, cfg, bus)
 
 	// Monitoring background processes
 	startMonitoringWithBus(db, cfg, emailProvider, bus)
@@ -155,6 +163,34 @@ func startMonitoringWithBus(db *sql.DB, cfg *config.Config, emailProvider *email
 		SchedulerMode:    cfg.SchedulerMode,
 	})
 	monitoringMod.StartBackgroundProcesses()
+}
+
+// subscribeIntegrationEvents builds the integration dispatch handler and subscribes
+// it to change-detected and alert-created domain events on the worker's bus. Detection
+// runs in the worker process, so the subscriber must live here too — otherwise events
+// published in this process reach no consumer and every delivery is dropped. Mirrors
+// cmd/server/modules.go's subscribeIntegrationEvents.
+func subscribeIntegrationEvents(db *sql.DB, cfg *config.Config, bus eventbus.MessageBus) {
+	orgRepo := orgpersistence.NewOrganizationPostgresRepository(db)
+	intRepoFactory := intwiring.NewTenantRepoFactory(db)
+	intOrgGuard := intwiring.NewOrgGuard(orgRepo)
+	twilioPlanLookup := intwiring.NewOrgPlanLookup(db)
+	intChannelEntitlement := intwiring.NewChannelEntitlementAdapter(twilioPlanLookup, cfg.IntegrationPaidPlans)
+	intDispatcher := dispatchevent.NewHandlerWithEntitlement(intRepoFactory, intOrgGuard, intChannelEntitlement)
+	intDispatcher.SetFallbackResolver(intwiring.NewMemberEmailResolver(db))
+
+	handle := func(ev eventbus.DomainEvent) {
+		if err := intDispatcher.Handle(context.Background(), ev); err != nil {
+			logger.Error("integration dispatch failed", zap.Error(err), zap.String("event_type", ev.Type))
+		}
+	}
+	if err := eventbus.SubscribeDomainEvent(bus, eventbus.TopicChangeDetected, handle); err != nil {
+		logger.Error("subscribe TopicChangeDetected", zap.Error(err))
+	}
+	if err := eventbus.SubscribeDomainEvent(bus, eventbus.TopicAlertCreated, handle); err != nil {
+		logger.Error("subscribe TopicAlertCreated", zap.Error(err))
+	}
+	logger.Info("Worker: integration event dispatcher subscribed (change.detected, alert.created)")
 }
 
 // buildIntegrationKey resolves and validates the integration token key,

--- a/modules/integration/application/dispatch_event/handler.go
+++ b/modules/integration/application/dispatch_event/handler.go
@@ -27,6 +27,12 @@ type OrgGuard interface {
 	IsActive(ctx context.Context, orgID uuid.UUID) (bool, error)
 }
 
+// FallbackRecipientResolver supplies the default recipient emails (a workspace's
+// active members) used to seed an email destination when none is configured yet.
+type FallbackRecipientResolver interface {
+	WorkspaceMemberEmails(ctx context.Context, tenant string, workspaceID uuid.UUID) ([]string, error)
+}
+
 // Handler dispatches a DomainEvent: it resolves matching destinations and
 // enqueues one Delivery row per destination (status=pending).
 //
@@ -49,10 +55,17 @@ type OrgGuard interface {
 // When entitlement is nil (NewHandler, legacy call sites) all destinations pass
 // through unchanged — this preserves backward compatibility.
 type Handler struct {
-	factory      RepoFactory
-	org          OrgGuard
-	entitlement  domainservices.ChannelEntitlement // optional; nil = all channels allowed
+	factory     RepoFactory
+	org         OrgGuard
+	entitlement domainservices.ChannelEntitlement // optional; nil = all channels allowed
+	fallback    FallbackRecipientResolver         // optional; nil = no default-email seeding
 }
+
+// SetFallbackResolver enables the default-email fallback: when an event resolves no
+// email destination, a workspace-scoped email destination is seeded from the
+// workspace's active members so change alerts reach the team without manual setup.
+// Optional — safe to leave unset (no seeding occurs).
+func (h *Handler) SetFallbackResolver(r FallbackRecipientResolver) { h.fallback = r }
 
 // NewHandler constructs a Handler without a channel entitlement gate.
 // All destinations are delivered regardless of the org's plan — use this only
@@ -65,6 +78,68 @@ func NewHandler(f RepoFactory, og OrgGuard) *Handler {
 // channel access via the supplied ChannelEntitlement port.
 func NewHandlerWithEntitlement(f RepoFactory, og OrgGuard, e domainservices.ChannelEntitlement) *Handler {
 	return &Handler{factory: f, org: og, entitlement: e}
+}
+
+// maybeSeedDefaultEmailDestination returns a newly-persisted workspace-scoped email
+// destination when the event resolved no email destination and the workspace has
+// active members. Returns nil (and never an error) otherwise — fallback is
+// best-effort and must never block other destinations from being delivered.
+func (h *Handler) maybeSeedDefaultEmailDestination(
+	ctx context.Context,
+	destRepo repositories.DestinationRepository,
+	ev eventbus.DomainEvent,
+	resolved []*entities.Destination,
+) *entities.Destination {
+	if h.fallback == nil || ev.WorkspaceID == nil {
+		return nil
+	}
+	for _, d := range resolved {
+		if strings.EqualFold(strings.TrimSpace(d.ServiceType), emailServiceType) {
+			return nil // a configured email destination already covers this event
+		}
+	}
+
+	// Re-check the workspace scope directly before seeding. ResolveForEvent already
+	// told us no email destination matched, but a concurrent dispatch for a sibling
+	// page in the same workspace may have seeded one in between — this narrows that
+	// race so we don't create a duplicate default destination.
+	if existing, lerr := destRepo.ListByScope(ctx, entities.ScopeWorkspace, *ev.WorkspaceID); lerr == nil {
+		for _, d := range existing {
+			if strings.EqualFold(strings.TrimSpace(d.ServiceType), emailServiceType) {
+				return nil
+			}
+		}
+	}
+
+	emails, err := h.fallback.WorkspaceMemberEmails(ctx, ev.Tenant, *ev.WorkspaceID)
+	if err != nil {
+		logger.Warn("dispatch: default-email fallback lookup failed",
+			zap.String("tenant", ev.Tenant), zap.Error(err))
+		return nil
+	}
+	if len(emails) == 0 {
+		return nil
+	}
+
+	dest := &entities.Destination{
+		ID:          uuid.New(),
+		ServiceType: emailServiceType,
+		ScopeType:   entities.ScopeWorkspace,
+		ScopeID:     *ev.WorkspaceID,
+		Target:      map[string]any{"emails": emails},
+		Events:      []string{eventbus.TopicChangeDetected, eventbus.TopicAlertCreated},
+		Enabled:     true,
+	}
+	if err := destRepo.Create(ctx, dest); err != nil {
+		logger.Warn("dispatch: failed to seed default email destination",
+			zap.String("tenant", ev.Tenant), zap.Error(err))
+		return nil
+	}
+	logger.Info("dispatch: seeded default email destination for workspace",
+		zap.String("tenant", ev.Tenant),
+		zap.String("workspace_id", ev.WorkspaceID.String()),
+		zap.Int("recipients", len(emails)))
+	return dest
 }
 
 // Handle is the entry point. It is safe to call concurrently.
@@ -81,6 +156,15 @@ func (h *Handler) Handle(ctx context.Context, ev eventbus.DomainEvent) error {
 	dests, err := destRepo.ResolveForEvent(ctx, ev.Type, ev.OrgID, ev.WorkspaceID, ev.PageID)
 	if err != nil {
 		return err
+	}
+
+	// Default-on fallback: when no email destination is configured for this event,
+	// seed a workspace-scoped email destination targeting the workspace's active
+	// members so change alerts reach the team without manual setup. Once seeded — or
+	// once the user configures emails in settings — this branch stops firing, so it
+	// never duplicates a configured destination.
+	if seeded := h.maybeSeedDefaultEmailDestination(ctx, destRepo, ev, dests); seeded != nil {
+		dests = append(dests, seeded)
 	}
 
 	// Plan-tiered channel gate: determine whether this org may use non-email channels.

--- a/modules/integration/application/dispatch_event/handler_test.go
+++ b/modules/integration/application/dispatch_event/handler_test.go
@@ -207,6 +207,18 @@ func (s *stubEntitlement) IsPaid(_ context.Context, _ uuid.UUID) (bool, error) {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// stubFallback is an in-memory FallbackRecipientResolver.
+type stubFallback struct {
+	emails []string
+	err    error
+	calls  int
+}
+
+func (s *stubFallback) WorkspaceMemberEmails(_ context.Context, _ string, _ uuid.UUID) ([]string, error) {
+	s.calls++
+	return s.emails, s.err
+}
+
 func newDest(serviceType string, scope entities.ScopeType, scopeID uuid.UUID, events []string) *entities.Destination {
 	return &entities.Destination{
 		ID:          uuid.New(),
@@ -233,6 +245,88 @@ func makeEvent(orgID uuid.UUID, wsID, pageID *uuid.UUID) eventbus.DomainEvent {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+// When no email destination resolves for the event, the handler seeds a
+// workspace-scoped email destination from the workspace's members and delivers to it.
+func TestDispatch_NoEmailDestination_SeedsWorkspaceMembersFallback(t *testing.T) {
+	orgID := uuid.New()
+	wsID := uuid.New()
+
+	destRepo := &inMemDestRepo{} // nothing configured
+	delRepo := &inMemDelRepo{}
+	h := NewHandlerWithEntitlement(&stubFactory{destRepo, delRepo}, &stubOrgGuard{isActive: true}, &stubEntitlement{emailOnly: true})
+	h.SetFallbackResolver(&stubFallback{emails: []string{"a@x.com", "b@x.com"}})
+
+	ev := makeEvent(orgID, &wsID, nil)
+	if err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if len(destRepo.dests) != 1 {
+		t.Fatalf("seeded destinations = %d, want 1", len(destRepo.dests))
+	}
+	d := destRepo.dests[0]
+	if d.ServiceType != "email" || d.ScopeType != entities.ScopeWorkspace || d.ScopeID != wsID || !d.Enabled {
+		t.Errorf("seeded destination wrong: %+v", d)
+	}
+	if !slices.Contains(d.Events, "change.detected") {
+		t.Errorf("seeded destination events = %v, want change.detected", d.Events)
+	}
+	if len(delRepo.created) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(delRepo.created))
+	}
+	if delRepo.created[0].DestinationID != d.ID {
+		t.Errorf("delivery destination = %v, want seeded %v", delRepo.created[0].DestinationID, d.ID)
+	}
+}
+
+// When an email destination already exists, the fallback must NOT fire (no seeding,
+// no duplicate) — the configured destination decides recipients.
+func TestDispatch_EmailDestinationExists_NoFallbackSeed(t *testing.T) {
+	orgID := uuid.New()
+	wsID := uuid.New()
+
+	existing := newDest("email", entities.ScopeOrg, orgID, []string{"change.detected"})
+	destRepo := &inMemDestRepo{dests: []*entities.Destination{existing}}
+	delRepo := &inMemDelRepo{}
+	fb := &stubFallback{emails: []string{"a@x.com"}}
+	h := NewHandlerWithEntitlement(&stubFactory{destRepo, delRepo}, &stubOrgGuard{isActive: true}, &stubEntitlement{emailOnly: true})
+	h.SetFallbackResolver(fb)
+
+	ev := makeEvent(orgID, &wsID, nil)
+	if err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if fb.calls != 0 {
+		t.Errorf("fallback invoked %d times, want 0 (email destination exists)", fb.calls)
+	}
+	if len(destRepo.dests) != 1 {
+		t.Errorf("destinations = %d, want 1 (no seeding)", len(destRepo.dests))
+	}
+	if len(delRepo.created) != 1 || delRepo.created[0].DestinationID != existing.ID {
+		t.Errorf("expected 1 delivery to the existing destination")
+	}
+}
+
+// No members to fall back to → no seed, no delivery.
+func TestDispatch_NoEmailDest_NoMembers_NoSeed(t *testing.T) {
+	orgID := uuid.New()
+	wsID := uuid.New()
+
+	destRepo := &inMemDestRepo{}
+	delRepo := &inMemDelRepo{}
+	h := NewHandlerWithEntitlement(&stubFactory{destRepo, delRepo}, &stubOrgGuard{isActive: true}, &stubEntitlement{emailOnly: true})
+	h.SetFallbackResolver(&stubFallback{emails: nil})
+
+	ev := makeEvent(orgID, &wsID, nil)
+	if err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(destRepo.dests) != 0 || len(delRepo.created) != 0 {
+		t.Errorf("expected no seed/delivery; dests=%d deliveries=%d", len(destRepo.dests), len(delRepo.created))
+	}
+}
 
 func TestDispatch_OrgOnly_OneDelivery(t *testing.T) {
 	orgID := uuid.New()

--- a/modules/integration/infrastructure/providers/email/client.go
+++ b/modules/integration/infrastructure/providers/email/client.go
@@ -46,11 +46,26 @@ func (c *Client) ListTargets(context.Context, *entities.Integration) ([]entities
 
 func (c *Client) Send(ctx context.Context, _ *entities.Integration, dest *entities.Destination, p *entities.NotificationPayload) (*entities.DeliveryResult, error) {
 	raw, _ := dest.Target["emails"].([]any)
+	// Collect recipients, trimming whitespace and removing case-insensitive
+	// duplicates so an address that appears both as a workspace member (seeded
+	// default) and as a manually-added recipient is emailed only once.
+	seen := make(map[string]struct{})
 	var emails []string
 	for _, v := range raw {
-		if s, ok := v.(string); ok && strings.Contains(s, "@") {
-			emails = append(emails, s)
+		s, ok := v.(string)
+		if !ok {
+			continue
 		}
+		s = strings.TrimSpace(s)
+		if !strings.Contains(s, "@") {
+			continue
+		}
+		key := strings.ToLower(s)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		emails = append(emails, s)
 	}
 	if len(emails) == 0 {
 		return nil, errors.New("email: no recipients")

--- a/modules/integration/infrastructure/providers/email/client_test.go
+++ b/modules/integration/infrastructure/providers/email/client_test.go
@@ -67,6 +67,18 @@ func TestEmailClient(t *testing.T) {
 			wantCode:   200,
 		},
 		{
+			name:       "deduplicates exact duplicate recipients",
+			target:     map[string]any{"emails": []any{"a@b.com", "a@b.com", "c@d.com"}},
+			wantSendTo: []string{"a@b.com", "c@d.com"},
+			wantCode:   200,
+		},
+		{
+			name:       "deduplicates case-insensitively and trims, keeps first-seen",
+			target:     map[string]any{"emails": []any{"  Member@X.com ", "member@x.com", "manual@x.com"}},
+			wantSendTo: []string{"Member@X.com", "manual@x.com"},
+			wantCode:   200,
+		},
+		{
 			name:       "empty list",
 			target:     map[string]any{"emails": []any{}},
 			wantErr:    "email: no recipients",

--- a/modules/snapshot/application/worker.go
+++ b/modules/snapshot/application/worker.go
@@ -817,63 +817,11 @@ func (s *SnapshotWorker) createAlert(ctx context.Context, schemaName string, che
 		logger.Info("Alert created", zap.String("check_id", check.ID.String()))
 	}
 
-	// Send email notifications asynchronously
-	go s.sendAlertEmails(schemaName, check, pageURL, changeSummary)
-
+	// Change-alert emails are delivered through the integration dispatch path
+	// (publishChangeDetected → integration dispatch_event → email/Slack/… destinations),
+	// which also covers settings-configured recipients, retry, and delivery history.
 	// Publish change.detected domain event so the integration dispatcher can fan-out.
 	go s.publishChangeDetected(ctx, schemaName, check, pageURL, changeSummary)
-}
-
-// sendAlertEmails queries notification preferences for the page and sends email alerts.
-func (s *SnapshotWorker) sendAlertEmails(schemaName string, check *snapEntities.Check, pageURL string, changeSummary string) {
-	if s.notificationEmailer == nil {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	prefs, err := s.monitoringReader.GetEmailEnabledByPage(ctx, schemaName, check.PageID)
-	if err != nil {
-		logger.Error("Failed to get email-enabled preferences", zap.Error(err))
-		return
-	}
-
-	if len(prefs) == 0 {
-		return
-	}
-
-	// Filter preferences by change_types: empty means all types, otherwise must include "page_change"
-	var filteredPrefs []*snapEntities.NotificationPreference
-	for _, pref := range prefs {
-		if len(pref.ChangeTypes) == 0 || sliceContains(pref.ChangeTypes, "page_change") {
-			filteredPrefs = append(filteredPrefs, pref)
-		}
-	}
-	if len(filteredPrefs) == 0 {
-		return
-	}
-
-	dashboardURL := fmt.Sprintf("%s/workspaces", s.frontendURL)
-	changeType := check.ChangeType
-	if changeType == "" {
-		changeType = "content"
-	}
-	// Use change summary as the change type description if available
-	if changeSummary != "" {
-		changeType = changeSummary
-	}
-
-	for _, pref := range filteredPrefs {
-		email, err := s.monitoringReader.GetUserEmail(ctx, pref.UserID)
-		if err != nil {
-			logger.Error("Failed to get user email for alert notification", zap.Error(err), zap.String("user_id", pref.UserID.String()))
-			continue
-		}
-		if err := s.notificationEmailer.SendAlertEmail(ctx, email, pageURL, changeType, dashboardURL); err != nil {
-			logger.Error("Failed to send alert email", zap.Error(err), zap.String("email", email))
-		}
-	}
 }
 
 // publishChangeDetected publishes a change.detected DomainEvent to the EventBus so that

--- a/shared/database/migrations/tenant/000030_unique_enabled_email_destination_per_scope.down.sql
+++ b/shared/database/migrations/tenant/000030_unique_enabled_email_destination_per_scope.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: unique_enabled_email_destination_per_scope
+-- Scope: tenant
+
+DROP INDEX IF EXISTS uq_integration_destinations_enabled_email_scope;

--- a/shared/database/migrations/tenant/000030_unique_enabled_email_destination_per_scope.up.sql
+++ b/shared/database/migrations/tenant/000030_unique_enabled_email_destination_per_scope.up.sql
@@ -1,0 +1,14 @@
+-- Migration: unique_enabled_email_destination_per_scope
+-- Scope: tenant
+-- Created: 2026-06-22T15:06:57Z
+
+-- Enforce at most ONE enabled email destination per scope (org/workspace/page).
+-- The change-alert dispatcher seeds a default email destination from workspace
+-- members when none is configured; under the worker's concurrent processing two
+-- sibling pages could otherwise race and seed duplicates, producing duplicate
+-- alert emails. This partial unique index makes the seeding Create fail atomically
+-- for the race loser instead. It also matches the product model: one email
+-- destination (holding a list of recipient emails) per scope.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_integration_destinations_enabled_email_scope
+    ON integration_destinations (scope_type, scope_id)
+    WHERE service_type = 'email' AND enabled;


### PR DESCRIPTION
The standalone worker runs change detection and publishes change.detected to its in-memory event bus, but only cmd/server subscribed the integration dispatcher — so the worker dropped every event and no integration_delivery was ever created (0 deliveries despite many detected changes). Subscribe the dispatcher in cmd/worker before detection starts.

Add a default-on fallback: when an event resolves no email destination, seed a workspace-scoped email destination from the workspace's active members so alerts reach the team without manual setup. Configured settings emails are included via the existing destination path. Deduplicate recipients case- insensitively in the email provider so a member who is also a manually-added recipient is emailed only once, and add a partial unique index enforcing one enabled email destination per scope to make the concurrent seed race fail atomically.