### PR TITLE
feat(monitoring): immediate run on enable + email/admin fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile for Pulzifi Backend
 # ============================================================
 
-.PHONY: help dev dev-web down logs build swagger clean migrate cms-migrate test test-integration test-billing-integration test-db-reset check-arch backup
+.PHONY: help dev dev-web down logs build swagger clean migrate cms-migrate test test-integration test-billing-integration test-db-reset e2e-notifications check-arch backup
 
 .DEFAULT_GOAL := help
 
@@ -33,6 +33,7 @@ help: ## Show this help message
 	@echo "  $(YELLOW)make test-integration$(NC)          - Run ALL integration tests against an isolated pulzifi_test DB"
 	@echo "  $(YELLOW)make test-billing-integration$(NC)  - Run billing-only integration tests (stripe webhook + plan assigner)"
 	@echo "  $(YELLOW)make test-db-reset$(NC)             - Drop and recreate the pulzifi_test DB from scratch"
+	@echo "  $(YELLOW)make e2e-notifications$(NC)         - Run the notification pipeline E2E smoke test (requires make dev + make dev-web)"
 	@echo ""
 	@echo "$(GREEN)BUILD:$(NC)"
 	@echo "  $(YELLOW)make build$(NC)    - Build API binary locally"
@@ -173,6 +174,11 @@ test-db-reset: check-env ## Drop and recreate pulzifi_test from scratch
 		go run ./cmd/migrate -db "$$TEST_DB_URL" -scope public -cmd up && \
 		go run ./cmd/migrate -db "$$TEST_DB_URL" -scope tenant -tenant $(TEST_TENANT) -cmd up && \
 		echo "$(GREEN)✓ $(TEST_DB_NAME) recreated and migrated$(NC)"
+
+# Notification pipeline E2E smoke test. Requires `make dev` + `make dev-web`
+# running. See tests/e2e/notification_pipeline_test.go for prerequisites.
+e2e-notifications: ## Run the notification pipeline E2E smoke test
+	go test -tags e2e -v -run TestNotificationPipeline ./tests/e2e/ -timeout 10m
 
 # ============================================================
 # BUILD

--- a/cmd/server/modules.go
+++ b/cmd/server/modules.go
@@ -91,8 +91,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// createEmailProvider creates the Resend email provider.
+// createEmailProvider selects the email provider from EMAIL_PROVIDER.
+// "log" is used for local/E2E testing so the pipeline never hits the real
+// Resend API; anything else (including unset) falls back to Resend.
 func createEmailProvider(cfg *config.Config) emailservices.EmailProvider {
+	if cfg.EmailProvider == "log" {
+		return emailproviders.NewLogProvider()
+	}
 	return emailproviders.NewResendProvider(cfg.ResendAPIKey, cfg.EmailFromAddress, cfg.EmailFromName)
 }
 

--- a/cmd/wiring/auth/membership_checker_test.go
+++ b/cmd/wiring/auth/membership_checker_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	authwiring "github.com/jcsoftdev/pulzifi-back/cmd/wiring/auth"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 	_ "github.com/lib/pq"
 )
 
@@ -34,12 +35,18 @@ func membershipTestDSN() string {
 	)
 }
 
+// openMembershipTestDB opens a connection for the membership checker
+// integration test. The test seeds and deletes real rows in public.users and
+// public.organizations, so it must never run against a shared/production
+// database picked up from ambient env vars (this has happened: leftover
+// membershiptest-* rows in prod broke the admin users page).
 func openMembershipTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	dsn := membershipTestDSN()
 	if dsn == "" {
 		t.Skip("DATABASE_URL (or DB_HOST) not set; skipping membership checker integration test")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/cmd/wiring/billing/plan_assigner_integration_test.go
+++ b/cmd/wiring/billing/plan_assigner_integration_test.go
@@ -16,6 +16,7 @@ import (
 	billingwiring "github.com/jcsoftdev/pulzifi-back/cmd/wiring/billing"
 	"github.com/jcsoftdev/pulzifi-back/modules/billing/domain/entities"
 	"github.com/jcsoftdev/pulzifi-back/modules/billing/domain/services"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 // openPlanAssignerTestDB returns a connected *sql.DB or calls t.Skip when
@@ -27,6 +28,7 @@ func openPlanAssignerTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL (or DB_HOST) not set; skipping billing wiring integration test")
 	}
+	testguard.RequireLocalDB(t, dsn)
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/cmd/wiring/snapshot/monitoring_reader_adapter.go
+++ b/cmd/wiring/snapshot/monitoring_reader_adapter.go
@@ -116,7 +116,7 @@ func (a *monitoringReaderAdapter) GetWorkspaceIDForPage(ctx context.Context, sch
 func (a *monitoringReaderAdapter) GetPageTitle(ctx context.Context, schemaName string, pageID uuid.UUID) (string, error) {
 	var title string
 	err := database.WithTenant(ctx, a.db, schemaName, func(tx *sql.Tx) error {
-		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(title,'') FROM pages WHERE id = $1`, pageID).Scan(&title); err != nil {
+		if err := tx.QueryRowContext(ctx, `SELECT COALESCE(name,'') FROM pages WHERE id = $1`, pageID).Scan(&title); err != nil {
 			return fmt.Errorf("get page title for page %s: %w", pageID, err)
 		}
 		return nil

--- a/cmd/wiring/social/emailer_adapter.go
+++ b/cmd/wiring/social/emailer_adapter.go
@@ -19,17 +19,17 @@ import (
 // the email module's EmailProvider. Recipients = active workspace members with
 // email_notifications_enabled = true.
 type emailerAdapter struct {
-	db          *sql.DB
-	provider    emailservices.EmailProvider
-	tenant      string
-	frontendURL string
+	db        *sql.DB
+	provider  emailservices.EmailProvider
+	tenant    string
+	appDomain string
 }
 
 var _ socialservices.SocialNotificationEmailer = (*emailerAdapter)(nil)
 
 // NewEmailer constructs a tenant-scoped SocialNotificationEmailer.
-func NewEmailer(db *sql.DB, provider emailservices.EmailProvider, tenant, frontendURL string) socialservices.SocialNotificationEmailer {
-	return &emailerAdapter{db: db, provider: provider, tenant: tenant, frontendURL: frontendURL}
+func NewEmailer(db *sql.DB, provider emailservices.EmailProvider, tenant, appDomain string) socialservices.SocialNotificationEmailer {
+	return &emailerAdapter{db: db, provider: provider, tenant: tenant, appDomain: appDomain}
 }
 
 // SendChangeEmail resolves recipients and emails each one. Best-effort per recipient.
@@ -38,7 +38,7 @@ func (a *emailerAdapter) SendChangeEmail(ctx context.Context, workspaceID uuid.U
 		return nil
 	}
 	if dashboardURL == "" {
-		dashboardURL = fmt.Sprintf("%s/workspaces", a.frontendURL)
+		dashboardURL = fmt.Sprintf("https://%s.%s/workspaces", a.tenant, a.appDomain)
 	}
 
 	emails, err := a.recipientEmails(ctx, workspaceID)

--- a/cmd/wiring/social/tenant_repo_factory.go
+++ b/cmd/wiring/social/tenant_repo_factory.go
@@ -138,7 +138,7 @@ func (f *TenantHandlerFactory) NewHandler(tenant string) *runcheck.Handler {
 	h.SetAlertRepo(socialpostgres.NewAlertPostgresRepository(f.db, tenant))
 	h.SetSSEPublisher(sseBrokerAdapter{b: f.broker})
 	if f.emailProvider != nil {
-		h.SetEmailer(NewEmailer(f.db, f.emailProvider, tenant, f.cfg.FrontendURL))
+		h.SetEmailer(NewEmailer(f.db, f.emailProvider, tenant, f.cfg.AppDomain))
 	}
 	if f.aiClient != nil {
 		h.SetInsightGenerator(NewInsightGenerator(f.aiClient, f.db, tenant))

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -41,6 +41,17 @@ import (
 	"go.uber.org/zap"
 )
 
+// createEmailProvider selects the email provider from EMAIL_PROVIDER.
+// "log" is used for local/E2E testing so the pipeline never hits the real
+// Resend API; anything else (including unset) falls back to Resend. Mirrors
+// cmd/server/modules.go's createEmailProvider.
+func createEmailProvider(cfg *config.Config) emailservices.EmailProvider {
+	if cfg.EmailProvider == "log" {
+		return emailproviders.NewLogProvider()
+	}
+	return emailproviders.NewResendProvider(cfg.ResendAPIKey, cfg.EmailFromAddress, cfg.EmailFromName)
+}
+
 func main() {
 	cfg := config.Load()
 	logger.Info("Starting Pulzifi Worker Service", zap.String("environment", cfg.Environment))
@@ -77,7 +88,7 @@ func main() {
 	}
 	defer bus.Close()
 
-	emailProvider := emailproviders.NewResendProvider(cfg.ResendAPIKey, cfg.EmailFromAddress, cfg.EmailFromName)
+	emailProvider := createEmailProvider(cfg)
 
 	// Wire the integration dispatcher onto the worker's bus BEFORE detection starts.
 	// Change detection runs in THIS process and publishes change.detected / alert.created
@@ -145,7 +156,7 @@ func main() {
 
 // startMonitoringWithBus builds the snapshot worker and starts the monitoring
 // module's background processes using the provided event bus.
-func startMonitoringWithBus(db *sql.DB, cfg *config.Config, emailProvider *emailproviders.ResendProvider, bus eventbus.MessageBus) {
+func startMonitoringWithBus(db *sql.DB, cfg *config.Config, emailProvider emailservices.EmailProvider, bus eventbus.MessageBus) {
 	snapshotWorker, err := monitoringwiring.NewSnapshotWorker(monitoringwiring.SnapshotWorkerDeps{
 		DB:            db,
 		EventBus:      bus,
@@ -212,7 +223,7 @@ func buildIntegrationKey(cfg *config.Config) []byte {
 }
 
 // buildProviderRegistry assembles the provider clients enabled by config.
-func buildProviderRegistry(db *sql.DB, cfg *config.Config, emailProvider *emailproviders.ResendProvider) services.ProviderRegistry {
+func buildProviderRegistry(db *sql.DB, cfg *config.Config, emailProvider emailservices.EmailProvider) services.ProviderRegistry {
 	slackClient := slackprovider.New(cfg.SlackClientID, cfg.SlackClientSecret)
 	intEmailClient := emailprovider.New(intwiring.NewEmailAdapter(emailProvider))
 	discordClient := discordprovider.New(cfg.DiscordClientID, cfg.DiscordClientSecret)
@@ -253,7 +264,7 @@ func startSocialScheduler(db *sql.DB, cfg *config.Config, bus eventbus.MessageBu
 }
 
 // buildDeliveryWorker wires the integration delivery worker from config.
-func buildDeliveryWorker(db *sql.DB, cfg *config.Config, emailProvider *emailproviders.ResendProvider) *deliveryworker.Worker {
+func buildDeliveryWorker(db *sql.DB, cfg *config.Config, emailProvider emailservices.EmailProvider) *deliveryworker.Worker {
 	intKey := buildIntegrationKey(cfg)
 	intEnc, err := crypto.NewAESGCM(intKey)
 	if err != nil {

--- a/frontend/apps/web/components/analytics-scripts.tsx
+++ b/frontend/apps/web/components/analytics-scripts.tsx
@@ -26,6 +26,7 @@ export function AnalyticsScripts() {
 
   const gaId = env.NEXT_PUBLIC_GA_ID
   const metaPixelId = env.NEXT_PUBLIC_META_PIXEL_ID
+  const clarityId = env.NEXT_PUBLIC_CLARITY_ID
 
   if (!isApex) return null
 
@@ -62,6 +63,16 @@ fbq('init', '${metaPixelId}');
 fbq('track', 'PageView');`}
           </Script>
         </>
+      )}
+      {clarityId && (
+        // biome-ignore lint/correctness/useUniqueElementIds: next/script inline tag needs a stable, single-use id for Clarity
+        <Script id="ms-clarity" strategy="afterInteractive">
+          {`(function(c,l,a,r,i,t,y){
+c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+})(window, document, "clarity", "script", "${clarityId}");`}
+        </Script>
       )}
     </>
   )

--- a/frontend/apps/web/features/super-admin/application/describe-load-error.ts
+++ b/frontend/apps/web/features/super-admin/application/describe-load-error.ts
@@ -1,0 +1,28 @@
+/**
+ * Maps an API error to a user-facing message for the super-admin panels.
+ * Handles both HttpError (SSR fetch client, `status`) and AxiosError
+ * (browser client, `response.status`).
+ */
+function errorStatus(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined
+  const e = err as {
+    status?: unknown
+    response?: {
+      status?: unknown
+    }
+  }
+  if (typeof e.status === 'number') return e.status
+  if (typeof e.response?.status === 'number') return e.response.status
+  return undefined
+}
+
+export function describeLoadError(err: unknown, resource: string): string {
+  switch (errorStatus(err)) {
+    case 401:
+      return 'Your session has expired. Please log in again.'
+    case 403:
+      return `You need SUPER_ADMIN role to manage ${resource}.`
+    default:
+      return `Failed to load ${resource}. Please try again.`
+  }
+}

--- a/frontend/apps/web/features/super-admin/ui/coupon-management.tsx
+++ b/frontend/apps/web/features/super-admin/ui/coupon-management.tsx
@@ -82,7 +82,9 @@ export function CouponManagement() {
 
   useEffect(() => {
     load()
-  }, [load])
+  }, [
+    load,
+  ])
 
   const handleCreate = async () => {
     setCreating(true)
@@ -120,7 +122,8 @@ export function CouponManagement() {
         <CardHeader>
           <CardTitle>Discount coupons</CardTitle>
           <CardDescription>
-            Create a "first month $1" promo for a plan. Customers redeem the code at checkout or via the apply link.
+            Create a "first month $1" promo for a plan. Customers redeem the code at checkout or via
+            the apply link.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-6">

--- a/frontend/apps/web/features/super-admin/ui/plan-management.tsx
+++ b/frontend/apps/web/features/super-admin/ui/plan-management.tsx
@@ -18,6 +18,7 @@ import {
 import { Gift, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useEffect, useState, useTransition } from 'react'
+import { describeLoadError } from '@/features/super-admin/application/describe-load-error'
 import { notification } from '@/lib/notification'
 
 export function PlanManagement() {
@@ -36,8 +37,8 @@ export function PlanManagement() {
       ])
       setPlans(plansData)
       setOrganizations(orgsData)
-    } catch {
-      setLoadError('You need SUPER_ADMIN role to manage organization plans.')
+    } catch (err) {
+      setLoadError(describeLoadError(err, 'organization plans'))
     }
   }, [])
 
@@ -90,7 +91,7 @@ export function PlanManagement() {
     })
   }
 
-if (loadError) {
+  if (loadError) {
     return (
       <div className="w-full">
         <Card>

--- a/frontend/apps/web/features/super-admin/ui/user-detail-sheet.tsx
+++ b/frontend/apps/web/features/super-admin/ui/user-detail-sheet.tsx
@@ -46,15 +46,22 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
     try {
       setDetail(await SuperAdminApi.getUser(userId))
     } catch {
-      notification.error({ title: 'Failed to load user' })
+      notification.error({
+        title: 'Failed to load user',
+      })
     } finally {
       setLoading(false)
     }
-  }, [userId])
+  }, [
+    userId,
+  ])
 
   useEffect(() => {
     if (open) load()
-  }, [open, load])
+  }, [
+    open,
+    load,
+  ])
 
   const toggleStatus = async () => {
     if (!detail) return
@@ -62,7 +69,9 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
     setBusy(true)
     try {
       await SuperAdminApi.setUserStatus(userId, next)
-      notification.success({ title: next === 'suspended' ? 'User suspended' : 'User activated' })
+      notification.success({
+        title: next === 'suspended' ? 'User suspended' : 'User activated',
+      })
       await load()
       onChanged()
     } catch (err) {
@@ -80,7 +89,9 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
     setBusy(true)
     try {
       await SuperAdminApi.promoteUser(userId)
-      notification.success({ title: 'Promoted to Super Admin' })
+      notification.success({
+        title: 'Promoted to Super Admin',
+      })
       await load()
       onChanged()
     } catch (err) {
@@ -97,7 +108,9 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
     setBusy(true)
     try {
       await SuperAdminApi.setMembershipRole(userId, orgId, role as 'OWNER' | 'ADMIN' | 'MEMBER')
-      notification.success({ title: 'Role updated' })
+      notification.success({
+        title: 'Role updated',
+      })
       await load()
       onChanged()
     } catch (err) {
@@ -114,7 +127,9 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
     setBusy(true)
     try {
       await SuperAdminApi.removeMembership(userId, orgId)
-      notification.success({ title: 'Removed from organization' })
+      notification.success({
+        title: 'Removed from organization',
+      })
       await load()
       onChanged()
     } catch (err) {
@@ -178,9 +193,7 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
 
             {/* Memberships */}
             <div className="space-y-3">
-              <p className="text-sm font-medium">
-                Organizations ({detail.memberships.length})
-              </p>
+              <p className="text-sm font-medium">Organizations ({detail.memberships.length})</p>
               {detail.memberships.length === 0 ? (
                 <p className="text-sm text-muted-foreground">No organization memberships.</p>
               ) : (
@@ -247,10 +260,7 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
       </AlertDialog>
 
       {/* Confirm remove membership */}
-      <AlertDialog
-        open={!!confirmRemove}
-        onOpenChange={(o) => !o && setConfirmRemove(null)}
-      >
+      <AlertDialog open={!!confirmRemove} onOpenChange={(o) => !o && setConfirmRemove(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Remove from organization?</AlertDialogTitle>
@@ -260,9 +270,7 @@ export function UserDetailSheet({ userId, open, onClose, onChanged }: Props) {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => confirmRemove && removeMembership(confirmRemove)}
-            >
+            <AlertDialogAction onClick={() => confirmRemove && removeMembership(confirmRemove)}>
               Remove
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/apps/web/features/super-admin/ui/user-management.tsx
+++ b/frontend/apps/web/features/super-admin/ui/user-management.tsx
@@ -19,6 +19,7 @@ import {
 import { ChevronLeft, ChevronRight, Loader2, ShieldCheck } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { describeLoadError } from '@/features/super-admin/application/describe-load-error'
 import { UserDetailSheet } from './user-detail-sheet'
 
 const PAGE_SIZE = 10
@@ -45,7 +46,9 @@ export function UserManagement({ initialOrgId = '' }: UserManagementProps) {
   useEffect(() => {
     setOrgId(initialOrgId)
     setPage(1)
-  }, [initialOrgId])
+  }, [
+    initialOrgId,
+  ])
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
@@ -62,8 +65,8 @@ export function UserManagement({ initialOrgId = '' }: UserManagementProps) {
       })
       setUsers(data.users ?? [])
       setTotal(data.total ?? 0)
-    } catch {
-      setLoadError('You need SUPER_ADMIN role to manage users.')
+    } catch (err) {
+      setLoadError(describeLoadError(err, 'users'))
     } finally {
       setLoading(false)
     }
@@ -71,7 +74,13 @@ export function UserManagement({ initialOrgId = '' }: UserManagementProps) {
 
   useEffect(() => {
     loadUsers(search, page, orgId, status)
-  }, [loadUsers, search, page, orgId, status])
+  }, [
+    loadUsers,
+    search,
+    page,
+    orgId,
+    status,
+  ])
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -184,11 +193,7 @@ export function UserManagement({ initialOrgId = '' }: UserManagementProps) {
                         )}
                       </td>
                       <td className="py-3 px-4 text-right">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setSelectedId(user.id)}
-                        >
+                        <Button variant="outline" size="sm" onClick={() => setSelectedId(user.id)}>
                           Manage
                         </Button>
                       </td>

--- a/frontend/packages/shared-http/src/env.ts
+++ b/frontend/packages/shared-http/src/env.ts
@@ -6,4 +6,5 @@ export const env = {
   COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
   NEXT_PUBLIC_GA_ID: process.env.NEXT_PUBLIC_GA_ID,
   NEXT_PUBLIC_META_PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID,
+  NEXT_PUBLIC_CLARITY_ID: process.env.NEXT_PUBLIC_CLARITY_ID,
 } as const

--- a/modules/auth/infrastructure/persistence/admin_user_postgres.go
+++ b/modules/auth/infrastructure/persistence/admin_user_postgres.go
@@ -45,7 +45,7 @@ func (r *AdminUserPostgresRepository) ListUsers(ctx context.Context, filter list
 	}
 
 	listQuery := `
-		SELECT u.id, u.email, u.first_name, u.last_name, u.status, u.email_verified,
+		SELECT u.id, u.email, COALESCE(u.first_name, ''), COALESCE(u.last_name, ''), u.status, COALESCE(u.email_verified, FALSE),
 		       EXISTS(
 		         SELECT 1 FROM public.user_roles ur
 		         JOIN public.roles ro ON ro.id = ur.role_id
@@ -84,7 +84,7 @@ func (r *AdminUserPostgresRepository) ListUsers(ctx context.Context, filter list
 // Implements getuserdetail.Reader.
 func (r *AdminUserPostgresRepository) GetUserDetail(ctx context.Context, id uuid.UUID) (*getuserdetail.UserDetail, error) {
 	const userQuery = `
-		SELECT u.id, u.email, u.first_name, u.last_name, u.status, u.email_verified,
+		SELECT u.id, u.email, COALESCE(u.first_name, ''), COALESCE(u.last_name, ''), u.status, COALESCE(u.email_verified, FALSE),
 		       EXISTS(SELECT 1 FROM public.user_roles ur
 		              JOIN public.roles ro ON ro.id = ur.role_id
 		              WHERE ur.user_id = u.id AND ro.name = 'SUPER_ADMIN') AS is_super_admin

--- a/modules/billing/infrastructure/persistence/postgres/plan_postgres_integration_test.go
+++ b/modules/billing/infrastructure/persistence/postgres/plan_postgres_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
+
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -17,6 +19,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL not set; skipping integration test")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("open db: %v", err)

--- a/modules/billing/infrastructure/persistence/postgres/webhook_event_postgres_test.go
+++ b/modules/billing/infrastructure/persistence/postgres/webhook_event_postgres_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -14,18 +15,43 @@ import (
 
 	"github.com/jcsoftdev/pulzifi-back/modules/billing/domain/entities"
 	"github.com/jcsoftdev/pulzifi-back/modules/billing/infrastructure/persistence/postgres"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 // TestMain cleans up any leftover test rows from interrupted runs.
+//
+// testguard.RequireLocalDB is not called here because TestMain has no
+// *testing.T to call t.Skip on — it can only os.Exit. Instead this mirrors
+// testguard's local-DSN policy inline before running the sweep. Every actual
+// test in this file also calls testguard.RequireLocalDB via
+// openBillingTestDB before touching the database, so this is belt-and-braces
+// for the pre-test cleanup sweep only.
 func TestMain(m *testing.M) {
 	dsn := billingTestDSN()
-	if dsn != "" {
+	if dsn != "" && isLocalOrAllowedRemoteDSN(dsn) {
 		if db, err := sql.Open("postgres", dsn); err == nil {
 			_, _ = db.Exec(`DELETE FROM public.stripe_webhook_events WHERE event_id LIKE 'evt_test_%'`)
 			db.Close()
 		}
 	}
 	os.Exit(m.Run())
+}
+
+// isLocalOrAllowedRemoteDSN mirrors testguard's local-DSN policy for use
+// outside of a *testing.T context.
+func isLocalOrAllowedRemoteDSN(dsn string) bool {
+	if os.Getenv("INTEGRATION_DB_ALLOW_REMOTE") == "1" {
+		return true
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return false
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1", "postgres", "host.docker.internal":
+		return true
+	}
+	return false
 }
 
 // openBillingTestDB returns a connected *sql.DB or calls t.Skip when
@@ -38,6 +64,7 @@ func openBillingTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL (or DB_HOST) not set; skipping billing integration test")
 	}
+	testguard.RequireLocalDB(t, dsn)
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/modules/email/infrastructure/providers/log_provider.go
+++ b/modules/email/infrastructure/providers/log_provider.go
@@ -1,0 +1,69 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/jcsoftdev/pulzifi-back/shared/logger"
+	"go.uber.org/zap"
+)
+
+// LogProvider implements EmailProvider by logging sends instead of calling a
+// real email API. It never sends real emails — intended for local development
+// and E2E tests so the notification pipeline can run without RESEND_API_KEY.
+type LogProvider struct {
+	captureFile string
+}
+
+// NewLogProvider creates a log-only email provider. If EMAIL_CAPTURE_FILE is
+// set, each Send() additionally appends a JSON line to that file so tests can
+// assert on delivered emails.
+func NewLogProvider() *LogProvider {
+	return &LogProvider{captureFile: os.Getenv("EMAIL_CAPTURE_FILE")}
+}
+
+// captureEntry is the JSON line format appended to the capture file.
+type captureEntry struct {
+	To      string `json:"to"`
+	Subject string `json:"subject"`
+	SentAt  string `json:"sent_at"`
+}
+
+// Send logs the email instead of delivering it, and optionally records it to
+// EMAIL_CAPTURE_FILE. Capture-file errors are logged but never returned —
+// this provider must never fail a caller relying on real email delivery
+// semantics.
+func (p *LogProvider) Send(_ context.Context, to, subject, _ string) error {
+	logger.Info("Email send (log provider — no real email sent)",
+		zap.String("to", to),
+		zap.String("subject", subject),
+	)
+
+	if p.captureFile == "" {
+		return nil
+	}
+
+	entry := captureEntry{To: to, Subject: subject, SentAt: time.Now().UTC().Format(time.RFC3339)}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		logger.Error("log email provider: failed to marshal capture entry", zap.Error(err))
+		return nil
+	}
+
+	f, err := os.OpenFile(p.captureFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		logger.Error("log email provider: failed to open capture file",
+			zap.String("path", p.captureFile), zap.Error(err))
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		logger.Error("log email provider: failed to write capture entry",
+			zap.String("path", p.captureFile), zap.Error(err))
+	}
+
+	return nil
+}

--- a/modules/email/infrastructure/providers/log_provider_test.go
+++ b/modules/email/infrastructure/providers/log_provider_test.go
@@ -1,0 +1,119 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	emailservices "github.com/jcsoftdev/pulzifi-back/modules/email/domain/services"
+	"github.com/jcsoftdev/pulzifi-back/shared/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// Compile-time assertion that LogProvider satisfies the shared EmailProvider port.
+var _ emailservices.EmailProvider = (*LogProvider)(nil)
+
+// TestLogProvider_Send_LogsAndSucceeds verifies that a send with no capture
+// file configured still succeeds and logs the recipient/subject at info level.
+func TestLogProvider_Send_LogsAndSucceeds(t *testing.T) {
+	t.Setenv("EMAIL_CAPTURE_FILE", "")
+
+	core, recorded := observer.New(zapcore.InfoLevel)
+	restore := swapLogger(zap.New(core))
+	defer restore()
+
+	p := NewLogProvider()
+	err := p.Send(context.Background(), "user@example.com", "Test Subject", "<p>hi</p>")
+	if err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+
+	found := false
+	for _, entry := range recorded.All() {
+		fields := entry.ContextMap()
+		if fields["to"] == "user@example.com" && fields["subject"] == "Test Subject" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected an info log entry with to=%q subject=%q, got entries=%+v",
+			"user@example.com", "Test Subject", recorded.All())
+	}
+}
+
+// TestLogProvider_Send_WritesCaptureFile verifies that when EMAIL_CAPTURE_FILE
+// is set, Send() appends a single JSON line with to/subject/sent_at fields.
+func TestLogProvider_Send_WritesCaptureFile(t *testing.T) {
+	capturePath := filepath.Join(t.TempDir(), "capture.jsonl")
+	t.Setenv("EMAIL_CAPTURE_FILE", capturePath)
+
+	p := NewLogProvider()
+	if err := p.Send(context.Background(), "to@example.com", "Hello", "body"); err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("failed to read capture file: %v", err)
+	}
+
+	line := strings.TrimSpace(string(data))
+	var entry struct {
+		To      string `json:"to"`
+		Subject string `json:"subject"`
+		SentAt  string `json:"sent_at"`
+	}
+	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		t.Fatalf("failed to parse capture line %q: %v", line, err)
+	}
+	if entry.To != "to@example.com" {
+		t.Errorf("captured to = %q, want %q", entry.To, "to@example.com")
+	}
+	if entry.Subject != "Hello" {
+		t.Errorf("captured subject = %q, want %q", entry.Subject, "Hello")
+	}
+	if entry.SentAt == "" {
+		t.Error("captured sent_at is empty, want a timestamp")
+	}
+}
+
+// TestLogProvider_Send_NoCaptureFileWhenEnvUnset verifies Send() succeeds and
+// never attempts to write a capture file when EMAIL_CAPTURE_FILE is unset.
+func TestLogProvider_Send_NoCaptureFileWhenEnvUnset(t *testing.T) {
+	t.Setenv("EMAIL_CAPTURE_FILE", "")
+
+	p := NewLogProvider()
+	if p.captureFile != "" {
+		t.Fatalf("captureFile = %q, want empty when EMAIL_CAPTURE_FILE is unset", p.captureFile)
+	}
+	if err := p.Send(context.Background(), "a@b.com", "s", "b"); err != nil {
+		t.Fatalf("Send() error = %v, want nil", err)
+	}
+}
+
+// TestLogProvider_Send_CaptureFileWriteFailureIsSwallowed verifies that a
+// capture file write failure (e.g. parent directory does not exist) never
+// bubbles up as an error from Send() — file capture is best-effort.
+func TestLogProvider_Send_CaptureFileWriteFailureIsSwallowed(t *testing.T) {
+	badPath := filepath.Join(t.TempDir(), "does-not-exist", "capture.jsonl")
+	t.Setenv("EMAIL_CAPTURE_FILE", badPath)
+
+	p := NewLogProvider()
+	if err := p.Send(context.Background(), "a@b.com", "s", "b"); err != nil {
+		t.Fatalf("Send() error = %v, want nil even when capture file write fails", err)
+	}
+}
+
+// swapLogger temporarily replaces the package-level logger.Logger and returns
+// a restore func. Needed because logger.Info/Error write through the global.
+func swapLogger(l *zap.Logger) (restore func()) {
+	original := logger.Logger
+	logger.Logger = l
+	return func() { logger.Logger = original }
+}

--- a/modules/integration/infrastructure/persistence/integration_postgres_test.go
+++ b/modules/integration/infrastructure/persistence/integration_postgres_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -16,11 +17,18 @@ import (
 	"github.com/jcsoftdev/pulzifi-back/modules/integration/domain/entities"
 	"github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/persistence"
 	"github.com/jcsoftdev/pulzifi-back/shared/crypto"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 // TestMain sweeps leftover test orgs/users from prior interrupted runs.
 // Belt-and-suspenders: each test also registers t.Cleanup, but that doesn't
 // run when the process is killed mid-run (panic, Ctrl+C, timeout).
+//
+// testguard.RequireLocalDB is not called here because TestMain has no
+// *testing.T to call t.Skip on — it can only os.Exit. Instead this mirrors
+// testguard's local-DSN policy inline before running the sweep. Every actual
+// test in this file also calls testguard.RequireLocalDB via openTestDB before
+// touching the database.
 func TestMain(m *testing.M) {
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -33,7 +41,7 @@ func TestMain(m *testing.M) {
 				os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), host, port, os.Getenv("DB_NAME"))
 		}
 	}
-	if dsn != "" {
+	if dsn != "" && isLocalOrAllowedRemoteDSN(dsn) {
 		if db, err := sql.Open("postgres", dsn); err == nil {
 			_, _ = db.Exec(`DELETE FROM public.organizations WHERE subdomain LIKE 'test-%' AND name LIKE 'Test Org %'`)
 			_, _ = db.Exec(`DELETE FROM public.users WHERE email LIKE 'testuser-%@example.com'`)
@@ -41,6 +49,23 @@ func TestMain(m *testing.M) {
 		}
 	}
 	os.Exit(m.Run())
+}
+
+// isLocalOrAllowedRemoteDSN mirrors testguard's local-DSN policy for use
+// outside of a *testing.T context.
+func isLocalOrAllowedRemoteDSN(dsn string) bool {
+	if os.Getenv("INTEGRATION_DB_ALLOW_REMOTE") == "1" {
+		return true
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return false
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1", "postgres", "host.docker.internal":
+		return true
+	}
+	return false
 }
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -61,6 +86,7 @@ func openTestDB(t *testing.T) *sql.DB {
 		password := os.Getenv("DB_PASSWORD")
 		dsn = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", user, password, host, port, name)
 	}
+	testguard.RequireLocalDB(t, dsn)
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/modules/integration/infrastructure/worker/delivery_processor_test.go
+++ b/modules/integration/infrastructure/worker/delivery_processor_test.go
@@ -27,6 +27,7 @@ import (
 	teamsprovider "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/providers/teams"
 	deliveryworker "github.com/jcsoftdev/pulzifi-back/modules/integration/infrastructure/worker"
 	"github.com/jcsoftdev/pulzifi-back/shared/crypto"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 // ---------------------------------------------------------------------------
@@ -48,6 +49,7 @@ func openWorkerTestDB(t *testing.T) *sql.DB {
 		dsn = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
 			os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), host, port, os.Getenv("DB_NAME"))
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/modules/monitoring/application/update_monitoring_config/handler.go
+++ b/modules/monitoring/application/update_monitoring_config/handler.go
@@ -45,7 +45,7 @@ func (h *UpdateMonitoringConfigHandler) Handle(ctx context.Context, pageID uuid.
 
 	// If config doesn't exist, create a new one with default values
 	if config == nil {
-		config, err = h.createConfig(ctx, pageID, req)
+		config, quotaExceeded, err = h.createConfig(ctx, pageID, req)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func (h *UpdateMonitoringConfigHandler) Handle(ctx context.Context, pageID uuid.
 // createConfig builds and persists a brand-new monitoring config, applying the
 // provided request fields over the defaults, then wakes the scheduler when the
 // new config is active.
-func (h *UpdateMonitoringConfigHandler) createConfig(ctx context.Context, pageID uuid.UUID, req *UpdateMonitoringConfigRequest) (*entities.MonitoringConfig, error) {
+func (h *UpdateMonitoringConfigHandler) createConfig(ctx context.Context, pageID uuid.UUID, req *UpdateMonitoringConfigRequest) (*entities.MonitoringConfig, bool, error) {
 	logger.Info("UpdateMonitoringConfigHandler: Config not found, creating new one")
 	// Set defaults for new config
 	checkFrequency := "Off"
@@ -168,21 +168,19 @@ func (h *UpdateMonitoringConfigHandler) createConfig(ctx context.Context, pageID
 		UpdatedAt:              time.Now(),
 	}
 
-	// Create in database — the scheduler will pick up the page on its
-	// next tick (last_checked_at is NULL, so it is immediately "due").
 	if err := h.repo.Create(ctx, config); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
+	// First-time setup: enabling monitoring on a page that had none should run
+	// a check immediately so the user gets instant feedback, instead of waiting
+	// for the scheduler's next tick.
+	quotaExceeded := false
 	if config.CheckFrequency != "Off" {
-		// Wake the scheduler so it re-evaluates next run time and picks
-		// up this newly created config promptly.
-		if h.scheduler != nil {
-			h.scheduler.WakeUp()
-		}
+		quotaExceeded = h.dispatchImmediate(ctx, pageID)
 	}
 
-	return config, nil
+	return config, quotaExceeded, nil
 }
 
 // mergeConfigFields copies the provided (non-nil) request fields onto the
@@ -260,7 +258,18 @@ func (h *UpdateMonitoringConfigHandler) applyUpdates(ctx context.Context, pageID
 	// Config exists, update only provided fields
 	logger.Info("UpdateMonitoringConfigHandler: Config found, updating", zap.Any("current_config", config))
 
+	// Capture the pre-merge frequency so we can detect a transition out of an
+	// inactive state (Off / unset) into an active one.
+	wasInactive := isInactiveFrequency(config.CheckFrequency)
+
 	shouldDispatch := h.mergeConfigFields(ctx, pageID, config, req)
+
+	// Re-enabling monitoring (Off -> active) should run a check immediately,
+	// regardless of when the page was last checked. mergeConfigFields only
+	// dispatches when the page is overdue, which never fires for a fresh enable.
+	if req.CheckFrequency != nil && wasInactive && config.CheckFrequency != "Off" {
+		shouldDispatch = true
+	}
 
 	config.UpdatedAt = time.Now()
 
@@ -299,6 +308,33 @@ func (h *UpdateMonitoringConfigHandler) applyUpdates(ctx context.Context, pageID
 	}
 
 	return quotaExceeded, nil
+}
+
+// isInactiveFrequency reports whether a frequency means the page is not
+// scheduled for checks (unset or explicitly "Off").
+func isInactiveFrequency(freq string) bool {
+	return freq == "" || freq == "Off"
+}
+
+// dispatchImmediate triggers an immediate check for the page, falling back to
+// marking the page due when no scheduler is wired. Returns whether the check
+// hit the quota cap. TriggerPageCheck claims the page atomically, so this is
+// safe to call without a separate pre-claim.
+func (h *UpdateMonitoringConfigHandler) dispatchImmediate(ctx context.Context, pageID uuid.UUID) bool {
+	if h.scheduler == nil {
+		if err := h.repo.MarkPageDueNow(ctx, pageID); err != nil {
+			logger.Error("UpdateMonitoringConfigHandler: Failed to mark page due now", zap.String("page_id", pageID.String()), zap.Error(err))
+		}
+		return false
+	}
+	if err := h.scheduler.TriggerPageCheck(ctx, h.tenant, pageID); err != nil {
+		if errors.Is(err, orchestrator.ErrQuotaExceeded) {
+			logger.Warn("UpdateMonitoringConfigHandler: Quota exceeded", zap.String("page_id", pageID.String()))
+			return true
+		}
+		logger.Error("UpdateMonitoringConfigHandler: Failed to trigger immediate check", zap.String("page_id", pageID.String()), zap.Error(err))
+	}
+	return false
 }
 
 // isPageDueForCheck returns true only if the page has been checked before AND

--- a/modules/monitoring/application/update_monitoring_config/handler_test.go
+++ b/modules/monitoring/application/update_monitoring_config/handler_test.go
@@ -13,6 +13,107 @@ import (
 
 func strPtr(s string) *string { return &s }
 
+// fakeScheduler records dispatch calls so tests can assert whether changing a
+// frequency triggered an immediate check.
+type fakeScheduler struct {
+	wakeUpCalls  int
+	triggerCalls int
+	triggerErr   error
+}
+
+func (f *fakeScheduler) WakeUp() { f.wakeUpCalls++ }
+
+func (f *fakeScheduler) TriggerPageCheck(_ context.Context, _ string, _ uuid.UUID) error {
+	f.triggerCalls++
+	return f.triggerErr
+}
+
+func (f *fakeScheduler) Start(_ context.Context) {}
+
+func TestUpdateMonitoringConfigHandler_ImmediateDispatch(t *testing.T) {
+	pageID := uuid.New()
+	now := time.Now()
+	recent := now.Add(-1 * time.Minute)
+	old := now.Add(-2 * time.Hour)
+
+	cfg := func(freq string) *entities.MonitoringConfig {
+		return &entities.MonitoringConfig{
+			ID:             uuid.New(),
+			PageID:         pageID,
+			CheckFrequency: freq,
+			ScheduleType:   "all_time",
+			Timezone:       "UTC",
+		}
+	}
+
+	tests := []struct {
+		name        string
+		existingCfg *entities.MonitoringConfig
+		lastChecked *time.Time
+		newFreq     string
+		wantTrigger bool
+	}{
+		{
+			name:        "re-enable from Off triggers immediately even when recently checked",
+			existingCfg: cfg("Off"),
+			lastChecked: &recent,
+			newFreq:     "1h",
+			wantTrigger: true,
+		},
+		{
+			name:        "active to active recently checked does not trigger",
+			existingCfg: cfg("1h"),
+			lastChecked: &recent,
+			newFreq:     "30m",
+			wantTrigger: false,
+		},
+		{
+			name:        "active to active overdue still triggers",
+			existingCfg: cfg("24h"),
+			lastChecked: &old,
+			newFreq:     "1h",
+			wantTrigger: true,
+		},
+		{
+			name:        "switching active to Off never triggers",
+			existingCfg: cfg("1h"),
+			lastChecked: &old,
+			newFreq:     "Off",
+			wantTrigger: false,
+		},
+		{
+			name:        "brand new active config triggers immediately",
+			existingCfg: nil,
+			lastChecked: nil,
+			newFreq:     "1h",
+			wantTrigger: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mocks.MockMonitoringConfigRepository{
+				GetByPageIDResult:      tt.existingCfg,
+				GetLastCheckedAtResult: tt.lastChecked,
+			}
+			sched := &fakeScheduler{}
+
+			handler := NewUpdateMonitoringConfigHandler(repo, nil, "test_tenant", sched)
+			_, err := handler.Handle(context.Background(), pageID, &UpdateMonitoringConfigRequest{
+				CheckFrequency: strPtr(tt.newFreq),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := sched.triggerCalls > 0
+			if got != tt.wantTrigger {
+				t.Errorf("immediate trigger: want %v, got %v (triggerCalls=%d)", tt.wantTrigger, got, sched.triggerCalls)
+			}
+		})
+	}
+}
+
 func TestUpdateMonitoringConfigHandler_Handle(t *testing.T) {
 	pageID := uuid.New()
 	configID := uuid.New()

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -95,6 +95,7 @@ type Config struct {
 	ResendAPIKey     string
 	EmailFromAddress string
 	EmailFromName    string
+	EmailProvider    string // EMAIL_PROVIDER — resend|log (default: resend). "log" logs/captures emails locally instead of calling Resend (E2E/local testing).
 
 	// OAuth
 	GoogleClientID       string
@@ -294,6 +295,7 @@ func Load() *Config {
 		ResendAPIKey:          getEnv("RESEND_API_KEY", ""),
 		EmailFromAddress:      getEnv("EMAIL_FROM_ADDRESS", "noreply@pulzifi.com"),
 		EmailFromName:         getEnv("EMAIL_FROM_NAME", "Pulzifi"),
+		EmailProvider:         getEnv("EMAIL_PROVIDER", "resend"),
 		GoogleClientID:        getEnv("GOOGLE_CLIENT_ID", ""),
 		GoogleClientSecret:    getEnv("GOOGLE_CLIENT_SECRET", ""),
 		GitHubClientID:        getEnv("GITHUB_CLIENT_ID", ""),

--- a/shared/config/config_email_provider_test.go
+++ b/shared/config/config_email_provider_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLoad_EmailProviderDefault verifies EMAIL_PROVIDER defaults to "resend"
+// when unset, preserving current production behavior.
+func TestLoad_EmailProviderDefault(t *testing.T) {
+	env := requiredEnv()
+	env["JWT_SECRET"] = "dev-secret"
+	setEnvMap(t, env)
+	os.Unsetenv("EMAIL_PROVIDER")
+
+	cfg := Load()
+
+	if cfg.EmailProvider != "resend" {
+		t.Errorf("EmailProvider default = %q, want %q", cfg.EmailProvider, "resend")
+	}
+}
+
+// TestLoad_EmailProviderFromEnv verifies EMAIL_PROVIDER can be overridden to
+// "log" so local/E2E runs never hit the real Resend API.
+func TestLoad_EmailProviderFromEnv(t *testing.T) {
+	env := requiredEnv()
+	env["JWT_SECRET"] = "dev-secret"
+	env["EMAIL_PROVIDER"] = "log"
+	setEnvMap(t, env)
+
+	cfg := Load()
+
+	if cfg.EmailProvider != "log" {
+		t.Errorf("EmailProvider = %q, want %q", cfg.EmailProvider, "log")
+	}
+}

--- a/shared/database/migrator_test.go
+++ b/shared/database/migrator_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jcsoftdev/pulzifi-back/shared/database"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -20,6 +21,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL not set — integration test requires a real PostgreSQL instance")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/shared/database/tenant_conn_test.go
+++ b/shared/database/tenant_conn_test.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jcsoftdev/pulzifi-back/shared/database"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 func TestWithTenant_RejectsInvalidSchema(t *testing.T) {
@@ -38,6 +39,7 @@ func openWithTenantTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL not set — integration test requires a real PostgreSQL instance")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)

--- a/shared/featureflags/flags_test.go
+++ b/shared/featureflags/flags_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jcsoftdev/pulzifi-back/shared/featureflags"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -19,6 +20,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatal(err)

--- a/shared/integrationusage/quota_test.go
+++ b/shared/integrationusage/quota_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/url"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -14,6 +15,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/jcsoftdev/pulzifi-back/shared/integrationusage"
+	"github.com/jcsoftdev/pulzifi-back/shared/testguard"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -22,6 +24,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	if dsn == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	testguard.RequireLocalDB(t, dsn)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatal(err)
@@ -32,9 +35,15 @@ func openTestDB(t *testing.T) *sql.DB {
 // TestMain sweeps leftover orgs/users from prior interrupted runs before any
 // test executes. Belt-and-suspenders: each test also registers t.Cleanup, but
 // that doesn't run when the suite is killed mid-run.
+//
+// testguard.RequireLocalDB is not called here because TestMain has no
+// *testing.T to call t.Skip on — it can only os.Exit. Instead this mirrors
+// testguard's local-DSN policy inline before running the sweep. Every actual
+// test in this file also calls testguard.RequireLocalDB via openTestDB before
+// touching the database.
 func TestMain(m *testing.M) {
 	dsn := os.Getenv("DATABASE_URL")
-	if dsn != "" {
+	if dsn != "" && isLocalOrAllowedRemoteDSN(dsn) {
 		if db, err := sql.Open("postgres", dsn); err == nil {
 			_, _ = db.Exec(`DELETE FROM organizations WHERE subdomain LIKE 'iq-test-%'`)
 			_, _ = db.Exec(`DELETE FROM users WHERE email LIKE 'iq-test-%@example.com'`)
@@ -42,6 +51,23 @@ func TestMain(m *testing.M) {
 		}
 	}
 	os.Exit(m.Run())
+}
+
+// isLocalOrAllowedRemoteDSN mirrors testguard's local-DSN policy for use
+// outside of a *testing.T context.
+func isLocalOrAllowedRemoteDSN(dsn string) bool {
+	if os.Getenv("INTEGRATION_DB_ALLOW_REMOTE") == "1" {
+		return true
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return false
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1", "postgres", "host.docker.internal":
+		return true
+	}
+	return false
 }
 
 // seedOrg inserts a fresh user + org and registers cleanup.

--- a/shared/testguard/guard.go
+++ b/shared/testguard/guard.go
@@ -1,0 +1,50 @@
+// Package testguard protects integration tests from running against shared
+// or production databases picked up from ambient environment variables.
+package testguard
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+// localHosts are hosts integration tests may write to without an explicit override.
+// RequireLocalDB skips the test unless the DSN host is local (localhost,
+// 127.0.0.1, ::1, postgres, host.docker.internal) or INTEGRATION_DB_ALLOW_REMOTE=1.
+var localHosts = map[string]struct{}{
+	"localhost":            {},
+	"127.0.0.1":            {},
+	"::1":                  {},
+	"postgres":             {},
+	"host.docker.internal": {},
+}
+
+// RequireLocalDB skips the test unless dsn points at a local/dev database or
+// the developer explicitly opts in via INTEGRATION_DB_ALLOW_REMOTE=1. Call
+// this immediately after resolving the DSN and before any sql.Open/Ping.
+func RequireLocalDB(t *testing.T, dsn string) {
+	t.Helper()
+	if isLocalDSN(dsn) {
+		return
+	}
+	if os.Getenv("INTEGRATION_DB_ALLOW_REMOTE") == "1" {
+		return
+	}
+	t.Skip("refusing to run destructive integration test against non-local database; set INTEGRATION_DB_ALLOW_REMOTE=1 to override")
+}
+
+// isLocalDSN reports whether dsn points at a database on a well-known local
+// host. It fails closed: unparseable DSNs or empty hostnames are treated as
+// non-local.
+func isLocalDSN(dsn string) bool {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	_, ok := localHosts[host]
+	return ok
+}

--- a/shared/testguard/guard_test.go
+++ b/shared/testguard/guard_test.go
@@ -1,0 +1,94 @@
+package testguard
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsLocalDSN(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want bool
+	}{
+		{
+			name: "localhost",
+			dsn:  "postgres://user:pass@localhost:5432/db?sslmode=disable",
+			want: true,
+		},
+		{
+			name: "loopback ipv4",
+			dsn:  "postgres://user:pass@127.0.0.1:5432/db",
+			want: true,
+		},
+		{
+			name: "docker host alias",
+			dsn:  "postgres://user:pass@host.docker.internal:5432/db",
+			want: true,
+		},
+		{
+			name: "compose service name postgres",
+			dsn:  "postgres://user:pass@postgres:5432/db",
+			want: true,
+		},
+		{
+			name: "remote host",
+			dsn:  "postgres://user:pass@prod-db.example.com:5432/db",
+			want: false,
+		},
+		{
+			name: "unparseable dsn",
+			dsn:  "postgres://user:pass@[::1/db", // malformed bracket, fails url.Parse
+			want: false,
+		},
+		{
+			name: "empty string",
+			dsn:  "",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isLocalDSN(tc.dsn)
+			if got != tc.want {
+				t.Errorf("isLocalDSN(%q) = %v, want %v", tc.dsn, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLocalDSN_LoopbackIPv6(t *testing.T) {
+	// ::1 must be bracketed in a URL authority to parse correctly.
+	got := isLocalDSN("postgres://user:pass@[::1]:5432/db")
+	if !got {
+		t.Errorf("isLocalDSN(bracketed ::1) = false, want true")
+	}
+}
+
+func TestRequireLocalDB_SkipsForRemoteDSNWithoutOverride(t *testing.T) {
+	os.Unsetenv("INTEGRATION_DB_ALLOW_REMOTE")
+
+	var subtestRef *testing.T
+	t.Run("remote", func(st *testing.T) {
+		subtestRef = st
+		RequireLocalDB(st, "postgres://user:pass@prod-db.example.com:5432/db")
+		st.Error("expected RequireLocalDB to skip before reaching this line")
+	})
+	if subtestRef == nil || !subtestRef.Skipped() {
+		t.Error("expected subtest to be marked skipped by RequireLocalDB")
+	}
+}
+
+func TestRequireLocalDB_AllowsRemoteWithOverride(t *testing.T) {
+	t.Setenv("INTEGRATION_DB_ALLOW_REMOTE", "1")
+
+	ran := false
+	t.Run("remote-with-override", func(t *testing.T) {
+		RequireLocalDB(t, "postgres://user:pass@prod-db.example.com:5432/db")
+		ran = true
+	})
+	if !ran {
+		t.Error("expected RequireLocalDB to allow test to proceed when override is set")
+	}
+}

--- a/tests/e2e/notification_pipeline_test.go
+++ b/tests/e2e/notification_pipeline_test.go
@@ -1,0 +1,406 @@
+//go:build e2e
+
+// Package e2e contains black-box smoke tests that exercise the FULL
+// notification pipeline end to end against a live `make dev` stack:
+//
+//	snapshot worker (change detection) -> EventBus "change.detected"
+//	-> integration dispatch_event (resolve/seed destinations, enqueue delivery)
+//	-> integration delivery worker -> email provider -> delivered
+//
+// This chain has broken silently twice with zero test coverage: once because
+// the in-memory EventBus had no subscriber wired, once because an adapter
+// queried a nonexistent `pages.title` column. This test exists so it can
+// never regress again without a loud, fast failure.
+//
+// Prerequisites
+//
+//   - `make dev` running (postgres, scraper/extractor, monolith API on :3000).
+//   - `make dev-web` running (Next.js on :3001; the Go monolith on :3000
+//     proxies unmatched routes to it, including the `/lecture-ai` demo page
+//     and its `/api/demo/lecture-ai` toggle endpoint).
+//   - The worker needs a way to actually send the email. Either:
+//     (a) EMAIL_PROVIDER=log set on the worker container, so it logs instead
+//     of calling a real provider, or
+//     (b) a real RESEND_API_KEY configured, in which case this test targets
+//     delivered@resend.dev — Resend's official safe test address that is
+//     always accepted and never actually delivered to an inbox.
+//
+// Run with:
+//
+//	make e2e-notifications
+//
+// Configuration (env vars, all optional — defaults match `make dev`):
+//
+//	E2E_DB_DSN   - postgres DSN reachable from the HOST (default matches
+//	               docker-compose's postgres port mapping + docker-compose.yml
+//	               DB_USER/DB_PASSWORD/DB_NAME defaults)
+//	E2E_API_URL  - Go monolith URL reachable from the HOST (default
+//	               http://localhost:3000)
+//	E2E_PAGE_URL - URL the WORKER container will fetch to render the demo
+//	               page. The worker runs inside the docker-compose network,
+//	               where the Go monolith is reachable at the `monolith`
+//	               service hostname (see docker-compose.yml), NOT localhost.
+//	               (default http://monolith:3000/lecture-ai)
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+
+	"github.com/jcsoftdev/pulzifi-back/shared/database"
+)
+
+const (
+	tenantSchema    = "e2e_notif"
+	tenantSubdomain = "e2e-notif"
+	seedEmail       = "e2e-notif@pulzifi.test"
+	testRecipient   = "delivered@resend.dev"
+)
+
+// repoRoot resolves the repository root from this test file's own location,
+// independent of the process working directory. `go test` sets cwd to the
+// package directory (tests/e2e/), so anything relying on a repo-root-relative
+// path (like shared/database.ProvisionTenantSchema, whose migration source
+// URL is built from os.Getwd()) would silently look in the wrong place if
+// called in-process from here. That is exactly why tenant provisioning below
+// shells out to `go run ./cmd/migrate` with an explicit Dir instead of
+// calling database.ProvisionTenantSchema directly.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed to resolve test file path")
+	}
+	// tests/e2e/notification_pipeline_test.go -> repo root is two levels up.
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+func getenvDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// TestNotificationPipeline drives the full change-detection -> email-delivery
+// pipeline against a live dev stack. See the package doc comment for
+// prerequisites and configuration.
+func TestNotificationPipeline(t *testing.T) {
+	dbDSN := getenvDefault("E2E_DB_DSN", "postgres://pulzifi_user:pulzifi_password@localhost:5434/pulzifi?sslmode=disable")
+	apiURL := getenvDefault("E2E_API_URL", "http://localhost:3000")
+	pageURL := getenvDefault("E2E_PAGE_URL", "http://monolith:3000/lecture-ai")
+
+	root := repoRoot(t)
+
+	// (a) Connect to Postgres, reachable from the HOST.
+	t.Log("connecting to database:", dbDSN)
+	db, err := sql.Open("postgres", dbDSN)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	pingCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(pingCtx); err != nil {
+		t.Skipf("database unreachable at %s (run `make dev` first): %v", dbDSN, err)
+	}
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	// (b) Toggle the demo page to version 1 (baseline content).
+	t.Log("setting demo page to version 1")
+	if err := postLectureAIVersion(httpClient, apiURL, "1"); err != nil {
+		t.Skipf("could not reach %s/api/demo/lecture-ai (run `make dev-web` first): %v", apiURL, err)
+	}
+
+	// (c) Seed tenant e2e_notif. Not deferred/cleaned up on failure so a
+	// broken run leaves inspectable state in the DB.
+	t.Log("dropping any stale e2e_notif schema/org/user")
+	if err := database.DeprovisionTenantSchema(db, tenantSchema); err != nil {
+		t.Fatalf("DeprovisionTenantSchema(%q): %v", tenantSchema, err)
+	}
+	if _, err := db.Exec(`DELETE FROM public.organizations WHERE schema_name = $1 OR subdomain = $2`, tenantSchema, tenantSubdomain); err != nil {
+		t.Fatalf("delete stale organization: %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM public.users WHERE email = $1`, seedEmail); err != nil {
+		t.Fatalf("delete stale user: %v", err)
+	}
+
+	t.Log("seeding public.users + public.organizations")
+	var userID uuid.UUID
+	if err := db.QueryRow(`
+		INSERT INTO public.users (email, password_hash, email_notifications_enabled, status)
+		VALUES ($1, 'not-a-real-hash', TRUE, 'approved')
+		RETURNING id`, seedEmail).Scan(&userID); err != nil {
+		t.Fatalf("insert seed user: %v", err)
+	}
+
+	var orgID uuid.UUID
+	if err := db.QueryRow(`
+		INSERT INTO public.organizations (name, subdomain, schema_name, owner_user_id)
+		VALUES ('E2E Notification Pipeline', $1, $2, $3)
+		RETURNING id`, tenantSubdomain, tenantSchema, userID).Scan(&orgID); err != nil {
+		t.Fatalf("insert seed organization: %v", err)
+	}
+
+	t.Log("provisioning tenant schema + running tenant migrations via `go run ./cmd/migrate`")
+	if err := runTenantMigrations(t, root, dbDSN, tenantSchema); err != nil {
+		t.Fatalf("tenant migration failed: %v", err)
+	}
+
+	// (d) Seed workspace, member, page, monitoring config.
+	t.Log("seeding workspace/workspace_member/page/monitoring_config")
+	var workspaceID, pageID uuid.UUID
+	err = database.WithTenant(context.Background(), db, tenantSchema, func(tx *sql.Tx) error {
+		if err := tx.QueryRow(`
+			INSERT INTO workspaces (name, type, created_by)
+			VALUES ('E2E Workspace', 'general', $1)
+			RETURNING id`, userID).Scan(&workspaceID); err != nil {
+			return fmt.Errorf("insert workspace: %w", err)
+		}
+
+		if _, err := tx.Exec(`
+			INSERT INTO workspace_members (workspace_id, user_id, role)
+			VALUES ($1, $2, 'owner')`, workspaceID, userID); err != nil {
+			return fmt.Errorf("insert workspace_member: %w", err)
+		}
+
+		if err := tx.QueryRow(`
+			INSERT INTO pages (workspace_id, name, url, created_by)
+			VALUES ($1, 'E2E Lecture AI Demo Page', $2, $3)
+			RETURNING id`, workspaceID, pageURL, userID).Scan(&pageID); err != nil {
+			return fmt.Errorf("insert page: %w", err)
+		}
+
+		// check_frequency='5m' (a valid, non-'Off' frequency key — see
+		// modules/monitoring/domain/entities/frequency.go). The scheduler's
+		// poll-mode due condition is:
+		//   check_frequency != 'Off' AND (last_checked_at IS NULL OR
+		//     last_checked_at < NOW() - INTERVAL <freq>)
+		// enabled_alert_conditions defaults to '["any_changes"]', which is
+		// required for the snapshot worker to call createAlert/publish
+		// change.detected at all.
+		if _, err := tx.Exec(`
+			INSERT INTO monitoring_configs (page_id, check_frequency)
+			VALUES ($1, '5m')`, pageID); err != nil {
+			return fmt.Errorf("insert monitoring_config: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed workspace/page/config: %v", err)
+	}
+
+	// (e) Seed an explicit email destination at workspace scope. A unique
+	// partial index (uq_integration_destinations_enabled_email_scope) allows
+	// at most one *enabled* email destination per scope, so this also
+	// prevents dispatch_event's own default-email fallback from creating a
+	// duplicate later.
+	t.Log("seeding integration_destinations (email, workspace scope)")
+	destinationID := uuid.New()
+	targetJSON, _ := json.Marshal(map[string]any{"emails": []string{testRecipient}})
+	err = database.WithTenant(context.Background(), db, tenantSchema, func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT INTO integration_destinations
+				(id, service_type, scope_type, scope_id, target, events, enabled)
+			VALUES ($1, 'email', 'workspace', $2, $3::jsonb, ARRAY['change.detected','alert.created'], TRUE)`,
+			destinationID, workspaceID, targetJSON)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed email destination: %v", err)
+	}
+
+	// (f) Ensure the page is due, then poll for the baseline check.
+	t.Log("marking page due and waiting for baseline check")
+	if err := markPageDue(db, tenantSchema, pageID); err != nil {
+		t.Fatalf("markPageDue (baseline): %v", err)
+	}
+
+	baselineOK := pollUntil(t, 90*time.Second, 3*time.Second, func() (bool, error) {
+		var count int
+		err := database.WithTenant(context.Background(), db, tenantSchema, func(tx *sql.Tx) error {
+			return tx.QueryRow(`
+				SELECT COUNT(*) FROM checks
+				WHERE page_id = $1 AND status = 'success'`, pageID).Scan(&count)
+		})
+		return count > 0, err
+	})
+	if !baselineOK {
+		dumpDebugState(t, db, tenantSchema, pageID)
+		t.Fatal("timed out waiting for baseline check to complete (90s) — is the worker running with ENABLE_WORKERS=true?")
+	}
+
+	// (g) Toggle content to version 2, mark the page due again, then poll
+	// for the delivered change.detected email.
+	t.Log("setting demo page to version 2 (content change)")
+	if err := postLectureAIVersion(httpClient, apiURL, "2"); err != nil {
+		t.Fatalf("toggle demo page to version 2: %v", err)
+	}
+
+	t.Log("marking page due again and waiting for change.detected -> delivered")
+	if err := markPageDue(db, tenantSchema, pageID); err != nil {
+		t.Fatalf("markPageDue (post-change): %v", err)
+	}
+
+	deliveredOK := pollUntil(t, 120*time.Second, 3*time.Second, func() (bool, error) {
+		var count int
+		err := database.WithTenant(context.Background(), db, tenantSchema, func(tx *sql.Tx) error {
+			return tx.QueryRow(`
+				SELECT COUNT(*) FROM integration_deliveries d
+				JOIN integration_destinations dest ON dest.id = d.destination_id
+				WHERE dest.id = $1 AND d.event_type = 'change.detected' AND d.status = 'delivered'`,
+				destinationID).Scan(&count)
+		})
+		return count > 0, err
+	})
+	if !deliveredOK {
+		dumpDebugState(t, db, tenantSchema, pageID)
+		t.Fatal("timed out waiting for change.detected delivery to reach status=delivered (120s)")
+	}
+
+	t.Log("notification pipeline E2E smoke test passed")
+}
+
+// postLectureAIVersion POSTs {"version": v} to the demo toggle endpoint.
+func postLectureAIVersion(client *http.Client, apiURL, version string) error {
+	body, _ := json.Marshal(map[string]string{"version": version})
+	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(apiURL, "/")+"/api/demo/lecture-ai", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from /api/demo/lecture-ai", resp.StatusCode)
+	}
+	return nil
+}
+
+// runTenantMigrations shells out to `go run ./cmd/migrate` instead of calling
+// database.ProvisionTenantSchema directly. ProvisionTenantSchema builds its
+// migration source URL from os.Getwd()+"shared/database/migrations/tenant",
+// assuming the process cwd is the repo root — true for a compiled binary or
+// `go run` invoked from root, but NOT true for `go test`, which always runs
+// with cwd set to the test's own package directory (tests/e2e/). Calling it
+// in-process here would silently look for migrations under
+// tests/e2e/shared/database/migrations/tenant, which does not exist.
+// Shelling out with an explicit Dir sidesteps that coupling entirely and
+// matches how the Makefile itself runs migrations.
+func runTenantMigrations(t *testing.T, repoRootDir, dbDSN, tenant string) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", "./cmd/migrate",
+		"-scope", "tenant",
+		"-tenant", tenant,
+		"-cmd", "up",
+		"-db", dbDSN,
+	)
+	cmd.Dir = repoRootDir
+	out, err := cmd.CombinedOutput()
+	t.Logf("migrate output:\n%s", out)
+	if err != nil {
+		return fmt.Errorf("go run ./cmd/migrate: %w", err)
+	}
+	return nil
+}
+
+// markPageDue resets last_checked_at/next_run_at so the page is immediately
+// due under BOTH scheduler modes:
+//   - poll (default, SCHEDULER_MODE unset): due when last_checked_at IS NULL
+//     or older than the configured frequency interval.
+//   - queue (SCHEDULER_MODE=queue): due when next_run_at IS NOT NULL and
+//     <= NOW().
+func markPageDue(db *sql.DB, tenant string, pageID uuid.UUID) error {
+	return database.WithTenant(context.Background(), db, tenant, func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			UPDATE pages
+			SET last_checked_at = NULL, next_run_at = NOW() - INTERVAL '1 minute'
+			WHERE id = $1`, pageID)
+		return err
+	})
+}
+
+// pollUntil calls check repeatedly until it returns true, an error, or the
+// timeout elapses. Returns whether check ever reported true.
+func pollUntil(t *testing.T, timeout, interval time.Duration, check func() (bool, error)) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ok, err := check()
+		if err != nil {
+			t.Logf("poll check error (continuing): %v", err)
+		} else if ok {
+			return true
+		}
+		time.Sleep(interval)
+	}
+	return false
+}
+
+// dumpDebugState logs alerts and integration_deliveries rows for the tenant
+// to aid debugging a timed-out run. Best-effort: logs and swallows its own
+// query errors rather than failing the test a second time.
+func dumpDebugState(t *testing.T, db *sql.DB, tenant string, pageID uuid.UUID) {
+	t.Helper()
+	_ = database.WithTenant(context.Background(), db, tenant, func(tx *sql.Tx) error {
+		rows, err := tx.Query(`
+			SELECT id, type, title, change_summary, created_at
+			FROM alerts WHERE page_id = $1 ORDER BY created_at DESC LIMIT 10`, pageID)
+		if err != nil {
+			t.Logf("dumpDebugState: query alerts: %v", err)
+		} else {
+			defer func() { _ = rows.Close() }()
+			t.Log("-- alerts for page --")
+			for rows.Next() {
+				var id, alertType, title, summary string
+				var createdAt time.Time
+				if err := rows.Scan(&id, &alertType, &title, &summary, &createdAt); err == nil {
+					t.Logf("alert id=%s type=%s title=%q summary=%q created_at=%s", id, alertType, title, summary, createdAt)
+				}
+			}
+		}
+
+		dRows, err := tx.Query(`
+			SELECT id, destination_id, event_type, status, attempts, error_message, created_at
+			FROM integration_deliveries ORDER BY created_at DESC LIMIT 10`)
+		if err != nil {
+			t.Logf("dumpDebugState: query integration_deliveries: %v", err)
+		} else {
+			defer func() { _ = dRows.Close() }()
+			t.Log("-- integration_deliveries (tenant-wide) --")
+			for dRows.Next() {
+				var id, destID, eventType, status string
+				var attempts int
+				var errMsg sql.NullString
+				var createdAt time.Time
+				if err := dRows.Scan(&id, &destID, &eventType, &status, &attempts, &errMsg, &createdAt); err == nil {
+					t.Logf("delivery id=%s dest=%s event=%s status=%s attempts=%d error=%q created_at=%s",
+						id, destID, eventType, status, attempts, errMsg.String, createdAt)
+				}
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Bundles the monitoring immediate-run feature with related fixes.

## Changes
- **feat(monitoring)**: run check immediately when enabling a frequency (inactive → active)
- **fix(snapshot)**: read page `name` instead of nonexistent `title` column
- **fix(social)**: link change emails to tenant subdomain instead of apex
- **fix(auth)**: coalesce nullable user columns in admin user queries
- **fix(super-admin)**: show real load error instead of assuming missing role
- **test(e2e)**: notification pipeline smoke test with log email provider
- **test(guard)**: refuse integration tests against non-local databases
- **feat(analytics)**: Clarity tracking script for apex domain