### PR TITLE
feat(integration): enrich page-change alert emails

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -280,7 +280,7 @@ func buildDeliveryWorker(db *sql.DB, cfg *config.Config, emailProvider emailserv
 		intRepoFactory,
 		intRepo,
 		intRegistry,
-		services.NewPayloadBuilder(),
+		services.NewPayloadBuilder(cfg.AppDomain),
 		deliveryworker.Config{
 			PollInterval: cfg.DeliveryPollInterval,
 			PoolSize:     cfg.DeliveryWorkerPoolSize,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-pulzifi_password}
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=en_US.UTF-8 --lc-ctype=en_US.UTF-8"
     ports:
-      - "${DB_PORT:-5434}:5432"
+      # Host-exposed port is non-standard to avoid clashing with any other
+      # project's Postgres (registry: pulzifi-back/postgresql=5436). Container
+      # still listens on the standard 5432 internally (network is isolated).
+      - "${DB_PORT:-5436}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql
       - ./database_setup.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
@@ -42,7 +45,8 @@ services:
     container_name: pulzifi-redis
     restart: unless-stopped
     ports:
-      - "${DEV_REDIS_PORT:-6381}:6379"
+      # Non-standard host port (registry: pulzifi-back/redis=6382).
+      - "${DEV_REDIS_PORT:-6382}:6379"
     volumes:
       - redis-data:/data
     networks:
@@ -57,7 +61,8 @@ services:
     image: localstack/localstack:3.0
     container_name: pulzifi-localstack
     ports:
-      - "${LOCALSTACK_PORT:-4566}:4566"
+      # Non-standard host port (registry: pulzifi-back/localstack=4567).
+      - "${LOCALSTACK_PORT:-4567}:4566"
     environment:
       - SERVICES=s3
       - DEBUG=1
@@ -131,13 +136,17 @@ services:
       MINIO_SECRET_KEY: test
       MINIO_BUCKET: ${MINIO_BUCKET:-pulzifi-snapshots}
       MINIO_USE_SSL: "false"
-      MINIO_PUBLIC_URL: http://localhost:${LOCALSTACK_PORT:-4566}
+      MINIO_PUBLIC_URL: http://localhost:${LOCALSTACK_PORT:-4567}
       EXTRACTOR_URL: http://scraper:3000
     env_file:
       - .env
     ports:
-      - "${HTTP_PORT:-3000}:3000"
-      - "${GRPC_PORT:-9000}:9000"
+      # Host-exposed ports are non-standard to avoid cross-project clashes
+      # (registry: go-chi=3002, grpc=9002). The app still listens on the
+      # standard 3000/9000 inside the isolated compose network (see the
+      # HTTP_PORT/GRPC_PORT under environment).
+      - "${HTTP_PORT:-3002}:3000"
+      - "${GRPC_HOST_PORT:-9002}:9000"
     volumes:
       - .:/workspace
     networks:
@@ -156,7 +165,8 @@ services:
     container_name: pulzifi-ollama
     restart: unless-stopped
     ports:
-      - "${OLLAMA_PORT:-11434}:11434"
+      # Non-standard host port (registry: pulzifi-back/ollama=11435).
+      - "${OLLAMA_PORT:-11435}:11434"
     volumes:
       - ollama-models:/root/.ollama
     networks:

--- a/frontend/packages/shared-http/src/tenant-utils.test.ts
+++ b/frontend/packages/shared-http/src/tenant-utils.test.ts
@@ -29,10 +29,14 @@ describe('extractTenantFromHostname', () => {
     { name: 'empty hostname', hostname: '', want: null },
     { name: 'two-label non-localhost base domain', hostname: 'example.com', want: null },
 
-    // Reserved subdomains are never tenants (label-based path)
+    // Reserved subdomains are never tenants — filtered on BOTH the label-based
+    // path (lvh.me) and the configured-app-domain path (pulzifi.com), so the
+    // result is deterministic regardless of env import timing.
     { name: 'www prefix on lvh.me', hostname: 'www.lvh.me', want: null },
     { name: 'api prefix on lvh.me', hostname: 'api.lvh.me', want: null },
     { name: 'admin prefix on lvh.me', hostname: 'admin.lvh.me', want: null },
+    { name: 'www prefix on app domain', hostname: 'www.pulzifi.com', want: null },
+    { name: 'api prefix on app domain', hostname: 'api.pulzifi.com', want: null },
   ]
 
   for (const c of cases) {
@@ -40,11 +44,4 @@ describe('extractTenantFromHostname', () => {
       expect(extractTenantFromHostname(c.hostname)).toBe(c.want)
     })
   }
-
-  // Characterization: the configured-app-domain branch does NOT filter reserved
-  // prefixes, so "www.<appDomain>" resolves to the literal "www". Documented so a
-  // future change to this behavior is a conscious decision, not an accident.
-  test('reserved prefix on the configured app domain is NOT filtered', () => {
-    expect(extractTenantFromHostname('www.pulzifi.com')).toBe('www')
-  })
 })

--- a/frontend/packages/shared-http/src/tenant-utils.ts
+++ b/frontend/packages/shared-http/src/tenant-utils.ts
@@ -4,6 +4,12 @@
  */
 import { env } from './env'
 
+// Subdomain labels that are infrastructure, never a tenant. Filtered on BOTH
+// the configured-app-domain path and the label-based fallback so a hostname
+// like "www.<appDomain>" resolves identically regardless of which branch runs
+// (the two branches otherwise diverge by env import timing).
+const RESERVED_SUBDOMAINS = new Set(['www', 'api', 'admin', 'app'])
+
 /**
  * Extracts tenant from hostname
  * @param hostname - The hostname (e.g., "tenant1.localhost", "tenant1.app.com", "www.app.com")
@@ -29,7 +35,10 @@ export function extractTenantFromHostname(hostname: string): string | null {
 
     if (normalizedHostname.endsWith(`.${appDomain}`)) {
       const tenantPart = normalizedHostname.slice(0, -(appDomain.length + 1))
-      return tenantPart || null
+      if (!tenantPart || RESERVED_SUBDOMAINS.has(tenantPart)) {
+        return null
+      }
+      return tenantPart
     }
   }
 
@@ -48,14 +57,8 @@ export function extractTenantFromHostname(hostname: string): string | null {
 
   const subdomain = parts[0] ?? ''
 
-  // Ignore common prefixes that aren't tenants
-  const ignoredSubdomains = [
-    'www',
-    'api',
-    'admin',
-    'app',
-  ]
-  if (ignoredSubdomains.includes(subdomain.toLowerCase())) {
+  // Ignore common prefixes that aren't tenants.
+  if (RESERVED_SUBDOMAINS.has(subdomain.toLowerCase())) {
     return null
   }
 

--- a/modules/integration/domain/entities/payload.go
+++ b/modules/integration/domain/entities/payload.go
@@ -6,10 +6,20 @@ type NotificationPayload struct {
 	EventType string
 	Title     string
 	Body      string
-	Severity  string         // info|warning|critical
+	Severity  string // info|warning|critical
 	Links     []Link
 	PageURL   string
 	Raw       map[string]any
+
+	// Enriched fields for change.detected — populated by PayloadBuilder from the
+	// event payload. Optional: empty when the source event does not carry them
+	// (e.g. alert.created), so renderers must degrade gracefully.
+	PageTitle    string // human-readable monitored page name
+	ChangeType   string // "content" | "visual"
+	DiffSummary  string // AI/structural summary of what changed
+	DiffImageURL string // public URL of the visual diff image, when available
+	DashboardURL string // deep link to the page's changes view in the tenant dashboard
+	ChangedAt    string // RFC3339 timestamp of the detecting check
 }
 
 type Link struct {

--- a/modules/integration/domain/services/payload_builder.go
+++ b/modules/integration/domain/services/payload_builder.go
@@ -8,9 +8,16 @@ import (
 	"github.com/jcsoftdev/pulzifi-back/shared/eventbus"
 )
 
-type PayloadBuilder struct{}
+// PayloadBuilder turns a raw DomainEvent into a provider-agnostic
+// NotificationPayload. appDomain is the apex application host (e.g. "pulzifi.com")
+// used to build tenant-subdomain dashboard deep links; empty disables them.
+type PayloadBuilder struct {
+	appDomain string
+}
 
-func NewPayloadBuilder() *PayloadBuilder { return &PayloadBuilder{} }
+func NewPayloadBuilder(appDomain string) *PayloadBuilder {
+	return &PayloadBuilder{appDomain: appDomain}
+}
 
 func (b *PayloadBuilder) Build(ev eventbus.DomainEvent) (*entities.NotificationPayload, error) {
 	var raw map[string]any
@@ -26,10 +33,7 @@ func (b *PayloadBuilder) Build(ev eventbus.DomainEvent) (*entities.NotificationP
 	}
 	switch ev.Type {
 	case eventbus.TopicChangeDetected:
-		p.Title = "Page change detected"
-		p.PageURL, _ = raw["page_url"].(string)
-		p.Body = fmt.Sprintf("A change was detected on %s", p.PageURL)
-		p.Severity = "warning"
+		b.buildChangeDetected(p, raw)
 	case eventbus.TopicAlertCreated:
 		p.Title, _ = raw["title"].(string)
 		p.Body, _ = raw["message"].(string)
@@ -39,4 +43,46 @@ func (b *PayloadBuilder) Build(ev eventbus.DomainEvent) (*entities.NotificationP
 		p.Body = "Pulzifi event"
 	}
 	return p, nil
+}
+
+// buildChangeDetected enriches the payload for a page change event, using the
+// summary, page name, change type, diff image and a dashboard deep link when
+// present. Falls back to the raw page URL when richer data is missing.
+func (b *PayloadBuilder) buildChangeDetected(p *entities.NotificationPayload, raw map[string]any) {
+	p.Severity = "warning"
+	p.PageURL, _ = raw["page_url"].(string)
+	p.PageTitle, _ = raw["page_title"].(string)
+	p.ChangeType, _ = raw["change_type"].(string)
+	p.DiffSummary, _ = raw["diff_summary"].(string)
+	p.DiffImageURL, _ = raw["diff_image_url"].(string)
+	p.ChangedAt, _ = raw["changed_at"].(string)
+	p.DashboardURL = b.changesLink(raw)
+
+	name := p.PageTitle
+	if name == "" {
+		name = p.PageURL
+	}
+	p.Title = fmt.Sprintf("Change detected on %s", name)
+
+	p.Body = p.DiffSummary
+	if p.Body == "" {
+		p.Body = fmt.Sprintf("A change was detected on %s", p.PageURL)
+	}
+}
+
+// changesLink builds the tenant-subdomain deep link to a page's changes view:
+//
+//	https://{tenant}.{appDomain}/workspaces/{workspaceID}/pages/{pageID}/changes
+//
+// Returns "" when appDomain is unset or any identifier is missing, so callers
+// can fall back to the raw page URL.
+func (b *PayloadBuilder) changesLink(raw map[string]any) string {
+	tenant, _ := raw["tenant"].(string)
+	workspaceID, _ := raw["workspace_id"].(string)
+	pageID, _ := raw["page_id"].(string)
+	if b.appDomain == "" || tenant == "" || workspaceID == "" || pageID == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s.%s/workspaces/%s/pages/%s/changes",
+		tenant, b.appDomain, workspaceID, pageID)
 }

--- a/modules/integration/domain/services/payload_builder_test.go
+++ b/modules/integration/domain/services/payload_builder_test.go
@@ -8,18 +8,20 @@ import (
 )
 
 func TestPayloadBuilder_Build(t *testing.T) {
-	builder := NewPayloadBuilder()
+	builder := NewPayloadBuilder("pulzifi.com")
 
 	tests := []struct {
-		name          string
-		event         eventbus.DomainEvent
-		wantSeverity  string
-		wantTitle     string
-		wantPageURL   string
-		wantErr       bool
+		name             string
+		event            eventbus.DomainEvent
+		wantSeverity     string
+		wantTitle        string
+		wantPageURL      string
+		wantBody         string
+		wantDashboardURL string
+		wantErr          bool
 	}{
 		{
-			name: "change detected event maps to warning severity",
+			name: "change detected falls back to page url when only url present",
 			event: eventbus.DomainEvent{
 				Type: eventbus.TopicChangeDetected,
 				Data: mustMarshal(t, map[string]any{
@@ -27,8 +29,46 @@ func TestPayloadBuilder_Build(t *testing.T) {
 				}),
 			},
 			wantSeverity: "warning",
-			wantTitle:    "Page change detected",
+			wantTitle:    "Change detected on https://example.com",
 			wantPageURL:  "https://example.com",
+			wantBody:     "A change was detected on https://example.com",
+		},
+		{
+			name: "change detected enriches title, summary and dashboard deep link",
+			event: eventbus.DomainEvent{
+				Type: eventbus.TopicChangeDetected,
+				Data: mustMarshal(t, map[string]any{
+					"page_url":     "https://example.com/pricing",
+					"page_title":   "Pricing Page",
+					"change_type":  "content",
+					"diff_summary": "Pro plan price rose from $29 to $39",
+					"tenant":       "acme",
+					"workspace_id": "ws-1",
+					"page_id":      "pg-1",
+				}),
+			},
+			wantSeverity:     "warning",
+			wantTitle:        "Change detected on Pricing Page",
+			wantPageURL:      "https://example.com/pricing",
+			wantBody:         "Pro plan price rose from $29 to $39",
+			wantDashboardURL: "https://acme.pulzifi.com/workspaces/ws-1/pages/pg-1/changes",
+		},
+		{
+			name: "change detected omits deep link when identifiers missing",
+			event: eventbus.DomainEvent{
+				Type: eventbus.TopicChangeDetected,
+				Data: mustMarshal(t, map[string]any{
+					"page_url":     "https://example.com",
+					"page_title":   "Home",
+					"diff_summary": "Header changed",
+					// no tenant/workspace_id/page_id
+				}),
+			},
+			wantSeverity:     "warning",
+			wantTitle:        "Change detected on Home",
+			wantPageURL:      "https://example.com",
+			wantBody:         "Header changed",
+			wantDashboardURL: "",
 		},
 		{
 			name: "alert created event maps to critical severity",
@@ -95,6 +135,12 @@ func TestPayloadBuilder_Build(t *testing.T) {
 			}
 			if tt.wantPageURL != "" && payload.PageURL != tt.wantPageURL {
 				t.Errorf("PageURL: want %q, got %q", tt.wantPageURL, payload.PageURL)
+			}
+			if tt.wantBody != "" && payload.Body != tt.wantBody {
+				t.Errorf("Body: want %q, got %q", tt.wantBody, payload.Body)
+			}
+			if payload.DashboardURL != tt.wantDashboardURL {
+				t.Errorf("DashboardURL: want %q, got %q", tt.wantDashboardURL, payload.DashboardURL)
 			}
 		})
 	}

--- a/modules/integration/infrastructure/providers/email/client.go
+++ b/modules/integration/infrastructure/providers/email/client.go
@@ -3,7 +3,6 @@ package emailprovider
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/jcsoftdev/pulzifi-back/modules/integration/domain/entities"
@@ -70,8 +69,9 @@ func (c *Client) Send(ctx context.Context, _ *entities.Integration, dest *entiti
 	if len(emails) == 0 {
 		return nil, errors.New("email: no recipients")
 	}
-	body := fmt.Sprintf(`<h2>%s</h2><p>%s</p><p><a href="%s">View page</a></p>`, p.Title, p.Body, p.PageURL)
-	if err := c.sender.Send(ctx, emails, p.Title, body); err != nil {
+	body := renderEmailHTML(p)
+	subject := sanitizeText(p.Title)
+	if err := c.sender.Send(ctx, emails, subject, body); err != nil {
 		return nil, err
 	}
 	return &entities.DeliveryResult{Code: 200}, nil

--- a/modules/integration/infrastructure/providers/email/client_test.go
+++ b/modules/integration/infrastructure/providers/email/client_test.go
@@ -177,3 +177,127 @@ func TestEmailClient(t *testing.T) {
 		})
 	}
 }
+
+func TestEmailClient_RichChangeBody(t *testing.T) {
+	stub := &stubSender{}
+	client := emailprovider.New(stub)
+
+	p := &entities.NotificationPayload{
+		Title:        "Change detected on Pricing Page",
+		Body:         "Pro plan price rose from $29 to $39",
+		PageURL:      "https://example.com/pricing",
+		PageTitle:    "Pricing Page",
+		ChangeType:   "content",
+		DiffImageURL: "https://storage.pulzifi.com/diffs/abc.png",
+		DashboardURL: "https://acme.pulzifi.com/workspaces/ws-1/pages/pg-1/changes",
+		ChangedAt:    "2026-07-17T19:18:00Z",
+	}
+	dest := makeDest(map[string]any{"emails": []any{"x@y.com"}})
+
+	if _, err := client.Send(context.Background(), makeIntegration(), dest, p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stub.calls) == 0 {
+		t.Fatal("expected Send to be called")
+	}
+	body := stub.calls[0].body
+
+	wantSubstrings := map[string]string{
+		"summary":       p.Body,
+		"page name":     p.PageTitle,
+		"diff image":    p.DiffImageURL,
+		"dashboard CTA": p.DashboardURL,
+		"CTA label":     "View changes",
+		"badge":         "content",
+	}
+	for label, want := range wantSubstrings {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %s (%q)", label, want)
+		}
+	}
+	// When a dashboard link exists, the CTA must NOT use the raw-page label.
+	if strings.Contains(body, "View page") {
+		t.Errorf("expected dashboard CTA, but body used raw-page label")
+	}
+}
+
+func TestEmailClient_SanitizesControlCharsAndSubject(t *testing.T) {
+	stub := &stubSender{}
+	client := emailprovider.New(stub)
+
+	// Title carries a CRLF (header-injection vector) + a control char; summary
+	// carries a NUL. Accented text must be preserved.
+	p := &entities.NotificationPayload{
+		Title:     "Change detected on Página\r\nBcc: evil@x.com",
+		Body:      "Precio\x00 subió de $29 a $39",
+		PageURL:   "https://example.com",
+		PageTitle: "Página\x07",
+	}
+	dest := makeDest(map[string]any{"emails": []any{"x@y.com"}})
+
+	if _, err := client.Send(context.Background(), makeIntegration(), dest, p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	call := stub.calls[0]
+
+	if strings.ContainsAny(call.subject, "\r\n") {
+		t.Errorf("subject still contains CR/LF (header injection): %q", call.subject)
+	}
+	if strings.ContainsRune(call.body, '\x00') || strings.ContainsRune(call.body, '\x07') {
+		t.Errorf("body still contains control characters")
+	}
+	// Legitimate accented text survives.
+	if !strings.Contains(call.body, "Precio") || !strings.Contains(call.subject, "Página") {
+		t.Errorf("expected accented text preserved; subject=%q", call.subject)
+	}
+}
+
+func TestEmailClient_NoDeadLinkWhenNoURLs(t *testing.T) {
+	// alert.created payloads carry only Title+Body (no page/dashboard URL). The
+	// CTA must be omitted entirely rather than render a dead <a href="">.
+	stub := &stubSender{}
+	client := emailprovider.New(stub)
+
+	p := &entities.NotificationPayload{
+		Title: "Quota threshold reached",
+		Body:  "You have used 90% of your monthly checks.",
+	}
+	dest := makeDest(map[string]any{"emails": []any{"x@y.com"}})
+
+	if _, err := client.Send(context.Background(), makeIntegration(), dest, p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := stub.calls[0].body
+	if strings.Contains(body, `href=""`) {
+		t.Errorf("rendered a dead empty-href link:\n%s", body)
+	}
+	if strings.Contains(body, "View page") || strings.Contains(body, "View changes") {
+		t.Errorf("expected no CTA button when no URL is present")
+	}
+	if !strings.Contains(body, p.Title) || !strings.Contains(body, p.Body) {
+		t.Errorf("expected title and body still rendered")
+	}
+}
+
+func TestEmailClient_FallsBackToPageURLWithoutDashboard(t *testing.T) {
+	stub := &stubSender{}
+	client := emailprovider.New(stub)
+
+	p := &entities.NotificationPayload{
+		Title:   "Change detected on https://example.com",
+		Body:    "A change was detected on https://example.com",
+		PageURL: "https://example.com",
+	}
+	dest := makeDest(map[string]any{"emails": []any{"x@y.com"}})
+
+	if _, err := client.Send(context.Background(), makeIntegration(), dest, p); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := stub.calls[0].body
+	if !strings.Contains(body, "View page") {
+		t.Errorf("expected 'View page' CTA fallback, body: %s", body)
+	}
+	if !strings.Contains(body, p.PageURL) {
+		t.Errorf("expected page URL in CTA fallback")
+	}
+}

--- a/modules/integration/infrastructure/providers/email/template.go
+++ b/modules/integration/infrastructure/providers/email/template.go
@@ -1,0 +1,107 @@
+package emailprovider
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/jcsoftdev/pulzifi-back/modules/integration/domain/entities"
+)
+
+// sanitizeText strips control characters (including CR/LF and tabs) from a
+// string and trims surrounding whitespace. It leaves printable Unicode intact,
+// so legitimate accented content survives. Used for both the email subject —
+// where a stray CR/LF would enable header injection — and the rendered body
+// fields, keeping the output free of stray/invisible special characters.
+func sanitizeText(s string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	return strings.TrimSpace(cleaned)
+}
+
+// changeEmailTmpl is a self-contained, inline-styled HTML email. Email clients
+// strip <style> blocks and external CSS, so every style is inline. Optional
+// blocks (badge, page name, diff image) render only when their data is present.
+var changeEmailTmpl = template.Must(template.New("change-email").Parse(`<div style="margin:0;padding:0;background:#f4f4f7;">
+  <div style="max-width:480px;margin:0 auto;padding:24px 0;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#1a1a2e;">
+    <div style="padding:0 8px 16px;font-size:18px;font-weight:700;letter-spacing:-0.02em;color:#6d28d9;">Pulzifi</div>
+    <div style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #ececf1;">
+      <div style="padding:24px;">
+        <h1 style="margin:0 0 8px;font-size:20px;line-height:1.3;font-weight:700;">{{.Title}}</h1>
+        <div style="margin:0 0 16px;font-size:13px;color:#6b7280;">
+          {{if .PageTitle}}<span>{{.PageTitle}}</span>{{end}}{{if .Badge}} <span style="color:#c4b5fd;">|</span> <span style="display:inline-block;padding:2px 8px;border-radius:999px;background:#f3e8ff;color:#6d28d9;font-weight:600;font-size:11px;text-transform:capitalize;">{{.Badge}}</span>{{end}}{{if .ChangedAt}} <span style="color:#c4b5fd;">|</span> <span>{{.ChangedAt}}</span>{{end}}
+        </div>
+        {{if .Summary}}<div style="margin:0 0 20px;padding:14px 16px;background:#faf9ff;border-left:3px solid #6d28d9;border-radius:6px;font-size:14px;line-height:1.5;color:#374151;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.04em;color:#9ca3af;margin-bottom:4px;font-weight:600;">What changed</div>{{.Summary}}</div>{{end}}
+        {{if .ImageURL}}{{if .CTAURL}}<a href="{{.CTAURL}}" style="display:block;margin:0 0 20px;"><img src="{{.ImageURL}}" alt="Visual diff preview" style="display:block;width:100%;max-width:100%;border-radius:8px;border:1px solid #ececf1;" /></a>{{else}}<img src="{{.ImageURL}}" alt="Visual diff preview" style="display:block;margin:0 0 20px;width:100%;max-width:100%;border-radius:8px;border:1px solid #ececf1;" />{{end}}{{end}}
+        {{if .CTAURL}}<a href="{{.CTAURL}}" style="display:inline-block;background:#6d28d9;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;padding:11px 20px;border-radius:8px;">{{.CTALabel}}</a>{{end}}
+      </div>
+    </div>
+    <div style="padding:16px 8px 0;font-size:11px;color:#9ca3af;line-height:1.5;">
+      You are receiving this because you monitor this page on Pulzifi.
+    </div>
+  </div>
+</div>`))
+
+// emailView is the flattened, render-ready projection of a NotificationPayload.
+type emailView struct {
+	Title     string
+	PageTitle string
+	Badge     string
+	ChangedAt string
+	Summary   string
+	ImageURL  string
+	CTALabel  string
+	CTAURL    string
+}
+
+// humanTime renders an RFC3339 timestamp as a compact, ASCII-only UTC label
+// (e.g. "Jul 17, 2026 14:18 UTC"). Non-RFC3339 input is returned unchanged.
+func humanTime(rfc string) string {
+	if rfc == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, rfc)
+	if err != nil {
+		return rfc
+	}
+	return t.UTC().Format("Jan 2, 2006 15:04 UTC")
+}
+
+// renderEmailHTML builds the branded HTML body for a notification. It works for
+// both enriched change.detected payloads and plainer events (alert.created),
+// showing only the fields that are present.
+func renderEmailHTML(p *entities.NotificationPayload) string {
+	v := emailView{
+		Title:     sanitizeText(p.Title),
+		PageTitle: sanitizeText(p.PageTitle),
+		Badge:     sanitizeText(p.ChangeType),
+		ChangedAt: humanTime(p.ChangedAt),
+		Summary:   sanitizeText(p.Body),
+		ImageURL:  p.DiffImageURL,
+	}
+
+	// Prefer the dashboard deep link; fall back to the raw monitored page URL.
+	if p.DashboardURL != "" {
+		v.CTAURL = p.DashboardURL
+		v.CTALabel = "View changes"
+	} else {
+		v.CTAURL = p.PageURL
+		v.CTALabel = "View page"
+	}
+
+	var buf bytes.Buffer
+	if err := changeEmailTmpl.Execute(&buf, v); err != nil {
+		// Template execution is deterministic; a failure means a programming
+		// error, not runtime data. Degrade to a minimal body rather than fail
+		// the whole delivery.
+		return "<h2>" + template.HTMLEscapeString(p.Title) + "</h2><p>" +
+			template.HTMLEscapeString(p.Body) + "</p>"
+	}
+	return buf.String()
+}

--- a/modules/snapshot/application/worker.go
+++ b/modules/snapshot/application/worker.go
@@ -865,11 +865,16 @@ func (s *SnapshotWorker) publishChangeDetected(parentCtx context.Context, tenant
 	}
 
 	payload := map[string]any{
-		"page_url":     pageURL,
-		"page_title":   pageTitle,
-		"change_type":  changeType,
-		"diff_summary": changeSummary,
-		"check_id":     check.ID.String(),
+		"page_url":       pageURL,
+		"page_title":     pageTitle,
+		"change_type":    changeType,
+		"diff_summary":   changeSummary,
+		"check_id":       check.ID.String(),
+		"page_id":        check.PageID.String(),
+		"workspace_id":   workspaceID.String(),
+		"tenant":         tenant,
+		"diff_image_url": check.DiffImageURL,
+		"changed_at":     check.CheckedAt.Format(time.RFC3339),
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/tests/e2e/notification_pipeline_test.go
+++ b/tests/e2e/notification_pipeline_test.go
@@ -100,8 +100,8 @@ func getenvDefault(key, fallback string) string {
 // pipeline against a live dev stack. See the package doc comment for
 // prerequisites and configuration.
 func TestNotificationPipeline(t *testing.T) {
-	dbDSN := getenvDefault("E2E_DB_DSN", "postgres://pulzifi_user:pulzifi_password@localhost:5434/pulzifi?sslmode=disable")
-	apiURL := getenvDefault("E2E_API_URL", "http://localhost:3000")
+	dbDSN := getenvDefault("E2E_DB_DSN", "postgres://pulzifi_user:pulzifi_password@localhost:5436/pulzifi?sslmode=disable")
+	apiURL := getenvDefault("E2E_API_URL", "http://localhost:3002")
 	pageURL := getenvDefault("E2E_PAGE_URL", "http://monolith:3000/lecture-ai")
 
 	root := repoRoot(t)


### PR DESCRIPTION
Replace the bare "A change was detected" email with a branded HTML template: page name, change-type badge, the AI/structural change summary, an optional visual-diff preview, and a "View changes" CTA deep-linking to the tenant dashboard (falls back to the monitored page URL when identifiers are missing).

- publishChangeDetected now carries page_id, workspace_id, tenant, diff_image_url and changed_at so downstream builders can enrich + link.
- PayloadBuilder takes appDomain to build the tenant-subdomain deep link.
- Email renders via html/template (auto-escaped), closing the previous raw fmt.Sprintf HTML-injection surface. CTA/image omit cleanly when no URL, so alert.created reuses the renderer without dead links.