### PR TITLE
ci: run bun unit tests via .test. filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,4 +185,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run type-check
-      - run: bun test
+      # `.test.` runs unit tests only. Playwright specs (apps/web/e2e/*.spec.ts)
+      # are `.spec.ts` and crash under `bun test`; bunfig pathIgnorePatterns is
+      # unreliable across bun versions, so this CLI filter is the real guard.
+      - run: bun test .test.

--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,2 +1,7 @@
 [test]
+# NOTE: bun's pathIgnorePatterns is unreliable here (it does not consistently
+# exclude apps/web/e2e/*.spec.ts across runs). The authoritative guard is the
+# `.test.` path filter passed to `bun test` in tools/scripts/validate-build.sh
+# and .github/workflows/ci.yml — unit tests are `.test.ts`, Playwright specs are
+# `.spec.ts`, so that filter runs unit tests only, deterministically.
 pathIgnorePatterns = ["**/e2e/**"]

--- a/tests/e2e/notification_pipeline_test.go
+++ b/tests/e2e/notification_pipeline_test.go
@@ -14,10 +14,12 @@
 //
 // Prerequisites
 //
-//   - `make dev` running (postgres, scraper/extractor, monolith API on :3000).
-//   - `make dev-web` running (Next.js on :3001; the Go monolith on :3000
-//     proxies unmatched routes to it, including the `/lecture-ai` demo page
-//     and its `/api/demo/lecture-ai` toggle endpoint).
+//   - `make dev` running (postgres, scraper/extractor, monolith API exposed on
+//     the host at :3002 — non-standard to avoid cross-project clashes; the
+//     container still listens on :3000 internally).
+//   - `make dev-web` running (Next.js on :3001; the Go monolith proxies
+//     unmatched routes to it, including the `/lecture-ai` demo page and its
+//     `/api/demo/lecture-ai` toggle endpoint).
 //   - The worker needs a way to actually send the email. Either:
 //     (a) EMAIL_PROVIDER=log set on the worker container, so it logs instead
 //     of calling a real provider, or
@@ -31,11 +33,12 @@
 //
 // Configuration (env vars, all optional — defaults match `make dev`):
 //
-//	E2E_DB_DSN   - postgres DSN reachable from the HOST (default matches
-//	               docker-compose's postgres port mapping + docker-compose.yml
-//	               DB_USER/DB_PASSWORD/DB_NAME defaults)
+//	E2E_DB_DSN   - postgres DSN reachable from the HOST (default targets the
+//	               non-standard exposed port :5436 — set DB_PORT=5436 in .env so
+//	               docker-compose publishes it there; the container listens on
+//	               5432 internally)
 //	E2E_API_URL  - Go monolith URL reachable from the HOST (default
-//	               http://localhost:3000)
+//	               http://localhost:3002)
 //	E2E_PAGE_URL - URL the WORKER container will fetch to render the demo
 //	               page. The worker runs inside the docker-compose network,
 //	               where the Go monolith is reachable at the `monolith`

--- a/tools/scripts/validate-build.sh
+++ b/tools/scripts/validate-build.sh
@@ -11,7 +11,10 @@ output=$(go vet ./... 2>&1) || ERRORS="${ERRORS}[vet] ${output}\n"
 # (biome lint, not format) — the gap that let a noDangerouslySetInnerHtml error ship.
 output=$(cd "$PROJECT_DIR/frontend" && bun run lint 2>&1) || ERRORS="${ERRORS}[fe-lint] ${output}\n"
 output=$(cd "$PROJECT_DIR/frontend" && bun run type-check 2>&1) || ERRORS="${ERRORS}[fe-types] ${output}\n"
-output=$(cd "$PROJECT_DIR/frontend" && bun test 2>&1) || ERRORS="${ERRORS}[fe-test] ${output}\n"
+# `.test.` filters to unit tests only — Playwright specs are `.spec.ts` and must
+# not be collected by bun test (they crash on test() setup). bun's bunfig
+# pathIgnorePatterns is unreliable, so the CLI filter is the authoritative guard.
+output=$(cd "$PROJECT_DIR/frontend" && bun test .test. 2>&1) || ERRORS="${ERRORS}[fe-test] ${output}\n"
 output=$(cd "$PROJECT_DIR" && make check-arch 2>&1) || ERRORS="${ERRORS}[arch] ${output}\n"
 
 if [ -n "$ERRORS" ]; then


### PR DESCRIPTION
Rescues two commits stranded after PR #62 was squash-merged before they were pushed.

## Changes
- **ci**: `bun test` collected the Playwright specs (`apps/web/e2e/*.spec.ts`) and crashed on their `test()` setup. bun's `bunfig` `pathIgnorePatterns` does not reliably exclude them across bun versions (works on CI's `latest`, fails on 1.3.14 locally), intermittently breaking the pre-commit hook and CI. Filter to `.test.` in both the pre-commit (`validate-build.sh`) and the CI frontend job — unit tests are `.test.ts`, Playwright specs are `.spec.ts`.
- **docs(e2e)**: correct the stale host-port references in the notification pipeline test after the port deconfliction (`:3000`→`:3002`, DSN `:5434`→`:5436`).

Net diff: 4 files (ci.yml, bunfig.toml, validate-build.sh, notification_pipeline_test.go). No runtime code touched.